### PR TITLE
Rebuild expansion flow, add incremental re-clustering, and chip feedback

### DIFF
--- a/server/database/SessionStore.js
+++ b/server/database/SessionStore.js
@@ -108,6 +108,31 @@ export const SessionStore = {
     return data;
   },
 
+  // insert new clusters without deleting existing ones (used for incremental re-clustering)
+  async saveNewClusters(sessionCode, clusters) {
+    if (!clusters.length) return [];
+
+    const rows = clusters.map(c => ({
+      session_code: sessionCode,
+      representative_query: c.representativeQuery,
+      submission_count: c.submissionCount,
+      questions: c.questions,
+      answer: null,
+      upvote_count: 0,
+      previewed_questions: [],
+      selected_questions: [],
+      contextual_facts: [],
+      participant_answers: []
+    }));
+
+    const { data, error } = await supabase
+      .from('clusters')
+      .insert(rows)
+      .select();
+    if (error) throw error;
+    return data;
+  },
+
   async deleteCluster(id) {
     const { error } = await supabase
       .from('clusters')

--- a/server/managers/ClusteringController.js
+++ b/server/managers/ClusteringController.js
@@ -94,6 +94,127 @@ Respond with ONLY the query string, nothing else.`;
 
   // generates previewed follow-up questions and contextual facts per cluster
   // takes current clusters with answers, participant answers, and any facts already in session
+  async generateFollowupSuggestions(clusterQuery, answer, questions = []) {
+    const questionList = questions.slice(0, 10).map(q => `- ${q.text ?? q}`).join('\n');
+
+    const prompt = `A group Q&A session just produced this answer from the host.
+
+Topic/question cluster: "${clusterQuery}"
+Host's answer: "${answer}"
+${questionList ? `\nSome of the questions that were asked:\n${questionList}` : ''}
+
+Generate exactly 3 short, natural follow-up questions a participant might want to ask after reading this answer. They should:
+- Build directly on what was answered, not repeat it
+- Be specific and concrete, not vague
+- Sound like something a real person would ask
+- Be under 15 words each
+
+Respond ONLY with a valid JSON array of 3 strings, no markdown, no explanation:
+["follow-up 1", "follow-up 2", "follow-up 3"]`;
+
+    try {
+      const response = await ai.models.generateContent({
+        model: 'gemini-2.5-flash',
+        contents: [{ role: 'user', parts: [{ text: prompt }] }]
+      });
+      const raw = response.text.trim()
+        .replace(/^```json\n?/, '').replace(/^```\n?/, '').replace(/```$/, '').trim();
+      const result = JSON.parse(raw);
+      if (!Array.isArray(result)) throw new Error('Expected array');
+      return result.slice(0, 3);
+    } catch (err) {
+      console.error('generateFollowupSuggestions error:', err);
+      return [];
+    }
+  }
+
+  // incremental clustering: assign new submissions to existing answered clusters OR create new ones
+  // returns { updatedClusters: [{ clusterId, addedQuestions }], newClusters: [{ representativeQuery, submissionCount, questions }] }
+  async incrementalCluster(newSubmissions, existingClusters, tags = []) {
+    const tagContext = tags.length ? `The session topic is: ${tags.join(', ')}.` : '';
+
+    const existingList = existingClusters
+      .map(c => `- Cluster ID "${c.id}": "${c.representative_query}"`)
+      .join('\n');
+
+    const submissionList = newSubmissions
+      .map((s, i) => `${i}: "${s.content}"`)
+      .join('\n');
+
+    const prompt = `You are helping organize new questions submitted during a live Q&A session.
+${tagContext}
+
+These clusters already exist and have been answered by the host. Do NOT change them — only add new questions to them if they fit:
+${existingList}
+
+These are NEW submissions that just came in (indexed 0 to ${newSubmissions.length - 1}):
+${submissionList}
+
+Your task:
+- For each new submission, either assign it to an existing cluster (if it fits semantically) OR group it with other unassigned submissions into a new cluster
+- If assigning to an existing cluster, use the exact Cluster ID string shown above
+- New clusters should only be created for questions that don't fit any existing cluster
+- For new clusters, write a clear representative query capturing the theme
+
+Respond ONLY with a valid JSON object, no markdown, no explanation:
+{
+  "assignments": [
+    { "submissionIndex": 0, "clusterId": "exact-uuid-from-above" }
+  ],
+  "newClusters": [
+    { "representativeQuery": "theme of new questions", "submissionIndices": [1, 2] }
+  ]
+}`;
+
+    try {
+      const response = await ai.models.generateContent({
+        model: 'gemini-2.5-flash',
+        contents: [{ role: 'user', parts: [{ text: prompt }] }]
+      });
+
+      const raw = response.text.trim()
+        .replace(/^```json\n?/, '').replace(/^```\n?/, '').replace(/```$/, '').trim();
+      const result = JSON.parse(raw);
+
+      if (!result.assignments || !result.newClusters) {
+        throw new Error('Gemini returned unexpected shape');
+      }
+
+      // build updatedClusters: map clusterId → questions to add
+      const addedMap = {}; // clusterId → submission[]
+      for (const { submissionIndex, clusterId } of result.assignments) {
+        const sub = newSubmissions[submissionIndex];
+        if (!sub) continue;
+        if (!addedMap[clusterId]) addedMap[clusterId] = [];
+        addedMap[clusterId].push({ text: sub.content, upvoteCount: 0 });
+      }
+
+      const updatedClusters = Object.entries(addedMap).map(([clusterId, addedQuestions]) => ({
+        clusterId,
+        addedQuestions,
+      }));
+
+      // build newClusters: format same as regular cluster() output
+      const newClusters = result.newClusters.map(nc => {
+        const questions = nc.submissionIndices
+          .map(i => newSubmissions[i])
+          .filter(Boolean)
+          .map(s => ({ text: s.content, upvoteCount: 0 }));
+        return {
+          representativeQuery: nc.representativeQuery,
+          submissionCount: questions.length,
+          questions,
+        };
+      });
+
+      return { updatedClusters, newClusters };
+
+    } catch (err) {
+      console.error('incrementalCluster error:', err);
+      throw new Error('Incremental clustering failed: ' + err.message);
+    }
+  }
+
   async generateExpansionPreview(clusters, tags = [], existingFacts = []) {
     const clusterSummary = clusters.map((c) => {
       const participantAnswers = (c.participant_answers ?? []).length

--- a/server/routes/Sessions.js
+++ b/server/routes/Sessions.js
@@ -42,7 +42,7 @@ router.post('/sessions/:code/close', async (req, res) => {
     const session = await sessionManager.getSessionAsync(req.params.code);
 
     if (!session) return res.status(404).json({ error: 'Session not found' });
-    if (session.phase !== 'OPEN') return res.status(400).json({ error: 'Session is not open' });
+    if (session.phase !== 'OPEN' && session.phase !== 'EXPANDING') return res.status(400).json({ error: 'Session is not accepting submissions' });
 
     await sessionManager.transitionPhase(req.params.code, 'CLOSED');
 
@@ -72,6 +72,42 @@ router.post('/sessions/:code/cluster', async (req, res) => {
     await sessionManager.transitionPhase(code, 'CLUSTERING');
     wsManager.toSession(code, 'session:clustering');
 
+    // --- incremental mode: answered clusters exist + new submissions since last cluster ---
+    const answeredClusters = (session.clusters ?? []).filter(c => c.answer);
+    const lastClusterIdx = session.submissionsAtLastCluster ?? 0;
+    const newSubs = session.submissions.slice(lastClusterIdx);
+
+    if (answeredClusters.length > 0 && newSubs.length > 0) {
+      // ask Gemini to assign new submissions to existing clusters OR form new ones
+      const { updatedClusters, newClusters } = await clusteringEngine.incrementalCluster(
+        newSubs, answeredClusters, session.tags
+      );
+
+      // update existing clusters that received new questions
+      for (const { clusterId, addedQuestions } of updatedClusters) {
+        const cluster = session.clusters.find(c => String(c.id) === String(clusterId));
+        if (!cluster) continue;
+        cluster.questions = [...(cluster.questions ?? []), ...addedQuestions];
+        cluster.submission_count = (cluster.submission_count ?? 0) + addedQuestions.length;
+        // persist to Supabase (fire-and-forget — don't block the response)
+        SessionStore.updateClusterQuery(clusterId, cluster.representative_query, cluster.submission_count, cluster.questions)
+          .catch(err => console.error('[incremental] failed to update cluster', clusterId, err));
+      }
+
+      // insert brand-new clusters (no answer yet)
+      let savedNew = [];
+      if (newClusters.length > 0) {
+        savedNew = await SessionStore.saveNewClusters(code, newClusters);
+        session.clusters.push(...savedNew);
+      }
+
+      session.submissionsAtLastCluster = session.submissions.length;
+      await sessionManager.transitionPhase(code, 'RESULTS');
+      wsManager.toSession(code, 'session:results', { clusters: session.clusters, submissionsAtLastCluster: session.submissions.length });
+      return res.json({ clusters: session.clusters });
+    }
+
+    // --- full cluster mode (first time, or no answered clusters yet) ---
     const clusters = await clusteringEngine.cluster(session.submissions, session.tags);
 
     // save and transition to results
@@ -95,7 +131,7 @@ router.post('/sessions/:code/cluster', async (req, res) => {
   }
 });
 
-// host triggers expansion — generates ai previewed questions and contextual facts
+// host opens a second round — participants submit new follow-up questions
 router.post('/sessions/:code/expand', async (req, res) => {
   try {
     const { code } = req.params;
@@ -104,42 +140,32 @@ router.post('/sessions/:code/expand', async (req, res) => {
     const session = sessionManager.getSession(code);
 
     if (!session) return res.status(404).json({ error: 'Session not found' });
-    if (session.phase !== 'RESULTS') return res.status(400).json({ error: 'Can only expand from RESULTS phase' });
-    if (session.clusters.length === 0) return res.status(400).json({ error: 'No clusters to expand' });
+    if (session.phase !== 'RESULTS') return res.status(400).json({ error: 'Can only open a second round from RESULTS phase' });
 
-    // transition to expanding and notify all
+    // transition to EXPANDING (submissions reopen) and notify everyone immediately
     await sessionManager.triggerExpansion(code);
     wsManager.toSession(code, 'session:expanding', { expansionRound: session.expansionRound });
+    res.json({ phase: 'EXPANDING', expansionRound: session.expansionRound });
 
-    // generate previewed questions and contextual facts from current cluster state
-    const preview = await clusteringEngine.generateExpansionPreview(
-      session.clusters,
-      session.tags,
-      session.contextualFacts
-    );
-
-    // save previews to clusters and contextual facts to session
-    await sessionManager.saveExpansionPreview(code, preview.clusterPreviews, preview.contextualFacts);
-
-    // broadcast previews to all clients so everyone can select
-    wsManager.toSession(code, 'expansion:preview', {
-      clusterPreviews: preview.clusterPreviews,
-      contextualFacts: preview.contextualFacts,
-      expansionRound: session.expansionRound
-    });
-
-    res.json({
-      clusterPreviews: preview.clusterPreviews,
-      contextualFacts: preview.contextualFacts,
-      expansionRound: session.expansionRound
-    });
+    // generate AI prompt suggestions async — push to participants when ready
+    clusteringEngine.generateExpansionPreview(session.clusters, session.tags, session.contextualFacts)
+      .then(preview => {
+        wsManager.toSession(code, 'expansion:prompts', {
+          prompts: preview.clusterPreviews.map(cp => ({
+            clusterId: cp.clusterId,
+            questions: cp.previewedQuestions,
+          }))
+        });
+      })
+      .catch(err => console.error('[expand] AI prompt generation failed:', err));
 
   } catch (err) {
     console.error(err);
-    // back to RESULTS so host can retry
     const sessionManager = req.app.locals.sessionManager;
-    await sessionManager.transitionPhase(req.params.code, 'RESULTS');
-    res.status(500).json({ error: 'Expansion failed. You can retry.' });
+    if (!res.headersSent) {
+      await sessionManager.transitionPhase(req.params.code, 'RESULTS');
+      res.status(500).json({ error: 'Failed to open second round. You can retry.' });
+    }
   }
 });
 
@@ -216,8 +242,16 @@ router.post('/sessions/:code/clusters/:clusterId/answer', async (req, res) => {
     const cluster = await sessionManager.updateClusterAnswer(code, clusterId, answer);
 
     wsManager.toSession(code, 'cluster:answered', { clusterId, answer });
-
     res.json(cluster);
+
+    // generate follow-up suggestions async — push to participants when ready
+    clusteringEngine.generateFollowupSuggestions(cluster.representative_query, answer, cluster.questions ?? [])
+      .then(suggestions => {
+        if (suggestions.length) {
+          wsManager.toSession(code, 'cluster:followups', { clusterId, suggestions });
+        }
+      })
+      .catch(err => console.error('[followups] generation failed:', err));
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Failed to save answer' });

--- a/src/components/ClusterList.css
+++ b/src/components/ClusterList.css
@@ -249,3 +249,32 @@
   white-space: nowrap;
   margin-left: 0.75rem;
 }
+/* ─── Round 2 banner (host EXPANDING view) ──────────────────────────────── */
+
+.hd-round2-banner {
+  background: #f0f4ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.hd-round2-title {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e40af;
+  margin-bottom: 0.25rem;
+}
+
+.hd-round2-sub {
+  font-size: 0.9rem;
+  color: #3730a3;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.hd-cluster--readonly {
+  opacity: 0.65;
+  pointer-events: none;
+}

--- a/src/components/ClusterList.jsx
+++ b/src/components/ClusterList.jsx
@@ -1,4 +1,3 @@
-import ExpansionPanel from "./ExpansionPanel";
 import Summary from "./Summary";
 import "./ClusterList.css";
 import React from "react";
@@ -37,18 +36,11 @@ export default function ClusterList({
   submissionCount,
   answers,
   editingAnswer,
-  expansionPreviews,
-  selectedQuestions,
-  manualQuestions,
   onDeleteCluster,
   onSetEditingAnswer,
   onAnswerChange,
   onSaveAnswer,
-  onToggleQuestion,
-  onManualChange,
-  onManualSubmit,
 }) {
-  const hasAnyPreview = Object.keys(expansionPreviews).length > 0;
   
   // Check if the session has ended. Display Summary if it has.
   if (phase === "ENDED" && clusters.length > 0) {
@@ -89,9 +81,29 @@ export default function ClusterList({
 
   if (phase === "EXPANDING") {
     return (
-      <div className="hd-waiting">
-        <div className="hd-waiting-title">Expanding the session…</div>
-        <p className="hd-waiting-sub">New questions are being sent to participants.</p>
+      <div className="hd-clusters">
+        <div className="hd-round2-banner">
+          <div className="hd-round2-title">Round 2 is open</div>
+          <p className="hd-round2-sub">Participants can now submit follow-up questions. Close submissions when ready, then cluster.</p>
+        </div>
+        {clusters.length > 0 && (
+          <>
+            <div className="hd-clusters-header">
+              <span className="hd-clusters-title">Round 1 results</span>
+            </div>
+            {clusters.map((cluster, i) => (
+              <div key={cluster.id} className="hd-cluster hd-cluster--readonly">
+                <div className="hd-cluster-top">
+                  <span className="hd-cluster-num">{i + 1}</span>
+                  <div className="hd-cluster-info">
+                    <div className="hd-cluster-query">{cluster.representative_query}</div>
+                    <div className="hd-cluster-count">{cluster.submission_count} submission{cluster.submission_count !== 1 ? "s" : ""}</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </>
+        )}
       </div>
     );
   }
@@ -109,9 +121,6 @@ export default function ClusterList({
         </div>
 
         {clusters.map((cluster, i) => {
-          const preview = expansionPreviews[cluster.id];
-          const selected = selectedQuestions[cluster.id] ?? new Set();
-
           return (
             <div key={cluster.id} className="hd-cluster">
               <div className="hd-cluster-top">
@@ -162,46 +171,6 @@ export default function ClusterList({
                 )}
               </div>
 
-              {phase === "RESULTS" && hasAnyPreview && (
-                <ExpansionPanel
-                  cluster={cluster}
-                  preview={preview}
-                  selected={selected}
-                  manualQuestion={manualQuestions[cluster.id]}
-                  onToggleQuestion={onToggleQuestion}
-                  onManualChange={onManualChange}
-                  onManualSubmit={onManualSubmit}
-                />
-                )}
-
-                {[...(selected)].map(question => (
-                <div key={question} className="hd-expansion-answer-area">
-                    <div className="hd-expansion-question-label">{question}</div>
-                    {editingAnswer === `${cluster.id}::${question}` ? (
-                    <>
-                        <textarea
-                        className="hd-answer-input"
-                        placeholder="Write a response to this question…"
-                        value={answers[`${cluster.id}::${question}`] ?? ""}
-                        onChange={e => onAnswerChange(`${cluster.id}::${question}`, e.target.value)}
-                        rows={3}
-                        />
-                        <div className="hd-answer-btns">
-                        <button className="hd-btn-save" onClick={() => onSaveAnswer(`${cluster.id}::${question}`)}>Save</button>
-                        <button className="hd-btn-ghost" onClick={() => onSetEditingAnswer(null)}>Cancel</button>
-                        </div>
-                    </>
-                    ) : (
-                    <div
-                        className={`hd-answer-display ${answers[`${cluster.id}::${question}`] ? 
-                        "has-answer" : "no-answer"}`}
-                        onClick={() => phase === "RESULTS" && onSetEditingAnswer(`${cluster.id}::${question}`)}
-                    >
-                        {answers[`${cluster.id}::${question}`] ?? "Click to write a response…"}
-                    </div>
-                    )}
-                </div>
-                ))}
             </div>
           );
         })}

--- a/src/components/Host.jsx
+++ b/src/components/Host.jsx
@@ -284,97 +284,17 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     socketRef.current.emit("host:delete_session", { code });
   }
 
-  // call ./components/ExpansionPanel.jsx to transition phase & get AI previewed questions back
-  async function fetchExpansionPreview() {
-    console.log("[fetchExpansionPreview] called — clusters:", clusters.map(c => c.id));
-    setPreviewLoading(true);
-    setError("");
-    const loadingState = {};
-    clusters.forEach(c => { loadingState[c.id] = { questions: [], loading: true }; });
-    setExpansionPreviews(loadingState);
-
-    try {
-      const res = await fetch(`/api/sessions/${code}/expand`, { method: "POST" });
-      const data = await res.json();
-      console.log("[fetchExpansionPreview] expand response — ok:", res.ok, "data:", data);
-      if (!res.ok) throw new Error(data.error);
-
-      const next = {};
-      (data.clusterPreviews ?? []).forEach(({ clusterId, previewedQuestions }) => {
-        console.log("[fetchExpansionPreview] mapping clusterId:", clusterId, "— looking in clusters:", clusters.map(c => c.id));
-        // fix: find by id, not array index (because my index attempts would never increase on prompt)
-        const cluster = clusters.find(c => c.id === clusterId);
-        console.log("[fetchExpansionPreview] matched cluster:", cluster ?? "NOT FOUND");
-        if (cluster) next[cluster.id] = { questions: previewedQuestions, loading: false };
-      });
-
-      console.log("[fetchExpansionPreview] final expansionPreviews to set:", next);
-      setExpansionPreviews(next);
-      setPhase("RESULTS");
-    } catch (err) {
-      console.error("[fetchExpansionPreview] error:", err);
-      setError(err.message ?? "Failed to load AI suggestions.");
-      const cleared = {};
-      clusters.forEach(c => { cleared[c.id] = { questions: [], loading: false }; });
-      setExpansionPreviews(cleared);
-    } finally {
-      setPreviewLoading(false);
-    }
-  }
-
-  // toggle a previewed question selection for a cluster
-  async function toggleQuestion(clusterId, question) {
-    setSelectedQuestions(prev => {
-      const current = new Set(prev[clusterId] ?? []);
-      current.has(question) ? current.delete(question) : current.add(question);
-      return { ...prev, [clusterId]: current };
-    });
-    try {
-      await fetch(`/api/sessions/${code}/clusters/${clusterId}/select`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question }),
-      });
-    } catch {
-      // revert optimistic update
-      setSelectedQuestions(prev => {
-        const current = new Set(prev[clusterId] ?? []);
-        current.has(question) ? current.delete(question) : current.add(question);
-        return { ...prev, [clusterId]: current };
-      });
-    }
-  }
-
-  // trigger expansion because it sends selected & manual questions are included in the transitions phase
-  async function triggerExpansion() {
+  // open a second round — participants get to submit new follow-up questions
+  async function openSecondRound() {
     setExpandLoading(true);
     setError("");
     try {
-      const expansionData = clusters.map(c => ({
-        clusterId: c.id,
-        selectedQuestions: [...(selectedQuestions[c.id] ?? [])],
-        manualQuestion: (manualQuestions[c.id] ?? "").trim(),
-      }));
-      const res = await fetch(`/api/sessions/${code}/expand`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ expansionData }),
-      });
+      const res = await fetch(`/api/sessions/${code}/expand`, { method: "POST" });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
-
-      // don't wait for sockets
-      if (data.clusterPreviews) {
-        const next = {};
-        data.clusterPreviews.forEach(({ clusterId, previewedQuestions }) => {
-          const cluster = clusters.find(c => c.id === clusterId);
-          if (cluster) next[cluster.id] = { questions: previewedQuestions, loading: false };
-        });
-        setExpansionPreviews(next);
-      }
-      setPhase("RESULTS");
+      setPhase("EXPANDING");
     } catch (err) {
-      setError(err.message ?? "Failed to trigger expansion.");
+      setError(err.message ?? "Failed to open second round.");
     } finally {
       setExpandLoading(false);
     }
@@ -458,7 +378,6 @@ export default function HostDashboard({ code: initialCode, onBack }) {
             tagInput={tagInput}
             error={error}
             actionLoading={actionLoading}
-            previewLoading={previewLoading}
             expandLoading={expandLoading}
             onTagInput={setTagInput}
             onAddTag={addTag}
@@ -466,8 +385,7 @@ export default function HostDashboard({ code: initialCode, onBack }) {
             canRecluster={submissionCount > submissionsAtLastCluster}
             onClose={closeSubmissions}
             onCluster={triggerClustering}
-            onPreviewExpansion={fetchExpansionPreview}
-            onTriggerExpansion={triggerExpansion}
+            onTriggerExpansion={openSecondRound}
             onEndSession={endSession}
             onDeleteSession={deleteSession}
           />
@@ -482,20 +400,13 @@ export default function HostDashboard({ code: initialCode, onBack }) {
           <ClusterList
             phase={phase}
             clusters={clusters}
-            submissions={submissions}
             submissionCount={submissionCount}
             answers={answers}
             editingAnswer={editingAnswer}
-            expansionPreviews={expansionPreviews}
-            selectedQuestions={selectedQuestions}
-            manualQuestions={manualQuestions}
             onDeleteCluster={deleteCluster}
             onSetEditingAnswer={setEditingAnswer}
             onAnswerChange={(id, val) => setAnswers(prev => ({ ...prev, [id]: val }))}
             onSaveAnswer={saveAnswer}
-            onToggleQuestion={toggleQuestion}
-            onManualChange={(id, val) => setManualQuestions(prev => ({ ...prev, [id]: val }))}
-            onManualSubmit={submitManualQuestion}
           />
         </main>
       </div>

--- a/src/components/HostSidebar.jsx
+++ b/src/components/HostSidebar.jsx
@@ -108,20 +108,6 @@ export default function HostSidebar({
             <button className="hd-btn-primary" onClick={onCluster} disabled={actionLoading || !canRecluster}>
               {actionLoading ? "Clustering…" : "Re-cluster"}
             </button>
-            <button
-              className="hd-btn-primary"
-              onClick={onPreviewExpansion}
-              disabled={previewLoading || expandLoading}
-            >
-              {previewLoading ? "Loading suggestions…" : "Preview Expansion"}
-            </button>
-            <button
-              className="hd-btn-primary hd-btn-expand"
-              onClick={onTriggerExpansion}
-              disabled={expandLoading || previewLoading}
-            >
-              {expandLoading ? "Expanding…" : "Trigger Expansion"}
-            </button>
             <button className="hd-btn-end" onClick={onEndSession} disabled={actionLoading}>
               {actionLoading ? "Ending…" : "End Session"}
             </button>
@@ -129,10 +115,14 @@ export default function HostSidebar({
         )}
 
         {phase === "EXPANDING" && (
-          <div className="hd-clustering-status">
-            <div className="hd-spinner" />
-            <span>Expansion in progress…</span>
-          </div>
+          <>
+            <button className="hd-btn-primary" onClick={onClose} disabled={actionLoading}>
+              {actionLoading ? "Closing…" : "Close Submissions"}
+            </button>
+            <button className="hd-btn-primary" onClick={onCluster} disabled={actionLoading}>
+              {actionLoading ? "Clustering…" : "Trigger Clustering"}
+            </button>
+          </>
         )}
 
         {phase === "ENDED" && (

--- a/src/components/Participant.css
+++ b/src/components/Participant.css
@@ -361,6 +361,65 @@
   text-align: center;
 }
 
+/* ─── Round 2 ────────────────────────────────────────────────────────────── */
+
+.pd-round2-banner {
+  background: #f0f4ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.pd-round2-title {
+  font-family: 'EB Garamond', serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e40af;
+  margin-bottom: 0.25rem;
+}
+
+.pd-round2-sub {
+  font-size: 0.9rem;
+  color: #3730a3;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.pd-prompts {
+  margin-bottom: 1.25rem;
+}
+
+.pd-prompts-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #a8a29e;
+  margin-bottom: 0.625rem;
+}
+
+.pd-prompts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.pd-prompt-item {
+  font-family: 'EB Garamond', serif;
+  font-size: 0.95rem;
+  font-style: italic;
+  color: #57534e;
+  background: #f8f8f7;
+  border: 1px solid #e5e4e1;
+  border-radius: 7px;
+  padding: 0.5rem 0.875rem;
+  line-height: 1.5;
+}
+
 .pd-clusters-header {
   display: flex;
   align-items: baseline;
@@ -574,4 +633,70 @@
   .pd-body { padding: 1.25rem 0.875rem; }
   .pd-card { padding: 1.125rem 1.25rem; }
   .pd-cluster { padding: 1rem 1.125rem; }
+}
+
+/* ─── Follow-up suggestions ──────────────────────────────────────────────── */
+
+.pd-followups {
+  margin-top: 0.875rem;
+  padding-top: 0.875rem;
+  border-top: 1px solid #f0efec;
+}
+
+.pd-followups-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: #a8a29e;
+  margin-bottom: 0.5rem;
+}
+
+.pd-followups-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.pd-followup-chip {
+  width: 100%;
+  text-align: left;
+  background: #f8f8f7;
+  border: 1px solid #e5e4e1;
+  border-radius: 7px;
+  padding: 0.5rem 0.875rem;
+  font-family: 'EB Garamond', serif;
+  font-size: 0.95rem;
+  font-style: italic;
+  color: #57534e;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+  line-height: 1.45;
+}
+
+.pd-followup-chip:hover:not(:disabled) {
+  border-color: #1c1917;
+  background: #ffffff;
+  color: #1c1917;
+}
+
+/* chip: submitted (confirmed) */
+.pd-followup-chip--done {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+  color: #15803d;
+  font-style: normal;
+  cursor: default;
+}
+
+/* chip: loading/submitting */
+.pd-followup-chip--loading {
+  background: #f5f4f2;
+  border-color: #e5e4e1;
+  color: #a8a29e;
+  cursor: wait;
+  font-style: normal;
 }

--- a/src/components/Participant.jsx
+++ b/src/components/Participant.jsx
@@ -15,6 +15,7 @@ export default function Participant({ code, onBack }) {
   const [answers, setAnswers] = useState({});
   const [upvotes, setUpvotes] = useState({});
   const [submissionCount, setSubmissionCount] = useState(0);
+  const [followups, setFollowups] = useState({}); // { [clusterId]: string[] }
   const [error, setError] = useState("");
   const [submitLoading, setSubmitLoading] = useState(false);
 
@@ -48,7 +49,11 @@ export default function Participant({ code, onBack }) {
       setClusters(clusters);
       setPhase("RESULTS");
     });
-    socket.on("session:ended",     () => setPhase("ENDED"));
+    socket.on("session:expanding",  () => setPhase("EXPANDING"));
+    socket.on("cluster:followups",  ({ clusterId, suggestions }) =>
+      setFollowups(prev => ({ ...prev, [clusterId]: suggestions }))
+    );
+    socket.on("session:ended",      () => setPhase("ENDED"));
     socket.on("cluster:deleted",   ({ clusterId }) =>
       setClusters(prev => prev.filter(c => c.id !== clusterId))
     );
@@ -243,8 +248,45 @@ export default function Participant({ code, onBack }) {
             answers={answers}
             myTexts={myTexts}
             upvotes={upvotes}
+            followups={followups}
             onUpvote={upvoteQuestion}
             onSubmitToCluster={submitToCluster}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (phase === "EXPANDING") {
+    return (
+      <div className="pd-root">
+        <ParticipantHeader phase={phase} code={code} onBack={onBack} />
+        <div className="pd-body">
+          <div className="pd-round2-banner">
+            <div className="pd-round2-title">Round 2 — Dig deeper</div>
+            <p className="pd-round2-sub">The host has answered the first round. Now's your chance to ask follow-up questions.</p>
+          </div>
+
+          {expansionPrompts.length > 0 && (
+            <div className="pd-prompts">
+              <div className="pd-prompts-label">Need inspiration? Here are some areas to explore:</div>
+              <ul className="pd-prompts-list">
+                {expansionPrompts.flatMap(p => p.questions).map((q, i) => (
+                  <li key={i} className="pd-prompt-item">{q}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <ParticipantInput
+            phase="OPEN"
+            submissions={submissions}
+            submittedCount={submissions.length}
+            inClusterCount={0}
+            submitLoading={submitLoading}
+            error={error}
+            onSubmit={submitQuestion}
+            onDelete={deleteSubmission}
           />
         </div>
       </div>

--- a/src/components/ParticipantCluster.jsx
+++ b/src/components/ParticipantCluster.jsx
@@ -3,11 +3,14 @@ import "./Participant.css";
 
 const MAX_CHARS = 500;
 
-function ClusterCard({ cluster, answer, myTexts, upvotes, phase, onUpvote, onSubmitToCluster }) {
+function ClusterCard({ cluster, answer, myTexts, upvotes, followups, phase, onUpvote, onSubmitToCluster }) {
   const [expanded, setExpanded] = useState(false);
   const [addingQuestion, setAddingQuestion] = useState(false);
   const [clusterInput, setClusterInput] = useState("");
   const [submitLoading, setSubmitLoading] = useState(false);
+  // chip feedback: track which chips are loading or confirmed
+  const [loadingChip, setLoadingChip] = useState(null);   // chip text currently submitting
+  const [submittedChips, setSubmittedChips] = useState(new Set()); // chips already submitted
 
   const questions = cluster.questions ?? [];
   const isEnded = phase === "ENDED";
@@ -21,6 +24,14 @@ function ClusterCard({ cluster, answer, myTexts, upvotes, phase, onUpvote, onSub
     setClusterInput("");
     setAddingQuestion(false);
     setSubmitLoading(false);
+  }
+
+  async function handleChipClick(q) {
+    if (loadingChip || submittedChips.has(q)) return;
+    setLoadingChip(q);
+    await onSubmitToCluster(cluster.id, q);
+    setSubmittedChips(prev => new Set([...prev, q]));
+    setLoadingChip(null);
   }
 
   return (
@@ -40,6 +51,29 @@ function ClusterCard({ cluster, answer, myTexts, upvotes, phase, onUpvote, onSub
         <div className="pd-cluster-answer">
           <span className="pd-answer-label">Host response</span>
           <p className="pd-answer-text">{answer}</p>
+        </div>
+      )}
+
+      {answer && followups?.length > 0 && !isEnded && (
+        <div className="pd-followups">
+          <div className="pd-followups-label">Want to dig deeper? Tap a question to ask it:</div>
+          <ul className="pd-followups-list">
+            {followups.map((q, i) => {
+              const isLoading = loadingChip === q;
+              const isSubmitted = submittedChips.has(q);
+              return (
+                <li key={i}>
+                  <button
+                    className={`pd-followup-chip ${isSubmitted ? "pd-followup-chip--done" : ""} ${isLoading ? "pd-followup-chip--loading" : ""}`}
+                    onClick={() => handleChipClick(q)}
+                    disabled={isLoading || isSubmitted}
+                  >
+                    {isLoading ? "Submitting…" : isSubmitted ? "✓ Submitted" : q}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
         </div>
       )}
 
@@ -130,6 +164,7 @@ export default function ParticipantClusterList({
   answers,
   myTexts,
   upvotes,
+  followups,
   onUpvote,
   onSubmitToCluster,
 }) {
@@ -155,6 +190,7 @@ export default function ParticipantClusterList({
           answer={answers[cluster.id]}
           myTexts={myTexts}
           upvotes={upvotes}
+          followups={followups?.[cluster.id]}
           phase={phase}
           onUpvote={onUpvote}
           onSubmitToCluster={onSubmitToCluster}


### PR DESCRIPTION
- Remove "Open Second Round" button; host answers now automatically trigger AI follow-up chips for participants via cluster:followups socket event
- Add incrementalCluster(): new submissions routed to answered clusters or new unanswered clusters — answered clusters preserve their answers
- Add saveNewClusters() to insert new clusters without wiping existing ones
- Chip tap now shows loading state then green confirmed state on submit