### PR TITLE
Fix real-time answers, tag editing, cluster numbering, favicon, and recluster button

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="src/assets/Favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>popularvote</title>
+    <title>PopularVote</title>
   </head>
   <body>
     <div id="root"></div>

--- a/server/database/SessionStore.js
+++ b/server/database/SessionStore.js
@@ -80,25 +80,40 @@ export const SessionStore = {
   },
 
   async saveClusters(sessionCode, clusters) {
+    // fetch existing clusters so we can preserve their answers
+    const { data: existing } = await supabase
+      .from('clusters')
+      .select('*')
+      .eq('session_code', sessionCode);
+
+    // build a lookup: representative_query -> existing cluster
+    const existingByQuery = {};
+    for (const c of (existing ?? [])) {
+      existingByQuery[c.representative_query] = c;
+    }
+
     const { error: deleteError } = await supabase
       .from('clusters')
       .delete()
       .eq('session_code', sessionCode);
     if (deleteError) throw deleteError;
 
-    const rows = clusters.map(c => ({
-      session_code: sessionCode,
-      representative_query: c.representativeQuery,
-      submission_count: c.submissionCount,
-      questions: c.questions,
-      answer: c.answer ?? null,
-      upvote_count: c.upvoteCount ?? 0,
-      // expansion fields
-      previewed_questions: c.previewedQuestions ?? [],
-      selected_questions: c.selectedQuestions ?? [],
-      contextual_facts: c.contextualFacts ?? [],
-      participant_answers: c.participantAnswers ?? []
-    }));
+    const rows = clusters.map(c => {
+      const prev = existingByQuery[c.representativeQuery];
+      return {
+        session_code: sessionCode,
+        representative_query: c.representativeQuery,
+        submission_count: c.submissionCount,
+        questions: c.questions,
+        // carry over answer, participant_answers, contextual_facts if query matches
+        answer: c.answer ?? prev?.answer ?? null,
+        upvote_count: c.upvoteCount ?? prev?.upvote_count ?? 0,
+        previewed_questions: c.previewedQuestions ?? prev?.previewed_questions ?? [],
+        selected_questions: c.selectedQuestions ?? prev?.selected_questions ?? [],
+        contextual_facts: c.contextualFacts ?? prev?.contextual_facts ?? [],
+        participant_answers: c.participantAnswers ?? prev?.participant_answers ?? [],
+      };
+    });
 
     const { data, error } = await supabase
       .from('clusters')

--- a/server/routes/Sessions.js
+++ b/server/routes/Sessions.js
@@ -236,15 +236,22 @@ router.post('/sessions/:code/clusters/:clusterId/answer', async (req, res) => {
   try {
     const { code, clusterId } = req.params;
     const { answer } = req.body;
+    const { question } = req.query;
     const sessionManager = req.app.locals.sessionManager;
     const wsManager = req.app.locals.wsManager;
 
-    const cluster = await sessionManager.updateClusterAnswer(code, clusterId, answer);
+    // follow-up answer — appends to participant_answers, never touches main answer
+    if (question) {
+      const cluster = await sessionManager.addParticipantAnswerToCluster(code, clusterId, answer);
+      wsManager.toSession(code, 'cluster:followup:answered', { clusterId, answer });
+      return res.json(cluster);
+    }
 
+    // main answer
+    const cluster = await sessionManager.updateClusterAnswer(code, clusterId, answer);
     wsManager.toSession(code, 'cluster:answered', { clusterId, answer });
     res.json(cluster);
 
-    // generate follow-up suggestions async — push to participants when ready
     clusteringEngine.generateFollowupSuggestions(cluster.representative_query, answer, cluster.questions ?? [])
       .then(suggestions => {
         if (suggestions.length) {
@@ -318,7 +325,8 @@ router.patch('/sessions/:code/tags', async (req, res) => {
 
     const session = await sessionManager.getSessionAsync(code);
     if (!session) return res.status(404).json({ error: 'Session not found' });
-    if (session.phase !== 'OPEN') return res.status(400).json({ error: 'Tags can only be updated while session is open' });
+    const editableTagPhases = ['OPEN', 'RESULTS', 'ENDED'];
+    if (!editableTagPhases.includes(session.phase)) return res.status(400).json({ error: 'Tags can only be updated in OPEN, RESULTS, or ENDED phase' });
 
     session.tags = tags;
     await SessionStore.updateTags(code, tags);

--- a/src/components/ClusterList.jsx
+++ b/src/components/ClusterList.jsx
@@ -147,44 +147,37 @@ export default function ClusterList({
               <ExpandableQuestions questions={cluster.questions} />
 
               <div className="hd-cluster-answer-area">
-                  {answers[cluster.id] && (
-                    <div className="hd-answer-display has-answer">
-                      {answers[cluster.id]}
-                    </div>
-                  )}
-
-                {phase === "RESULTS" && (
+                {editingAnswer === cluster.id ? (
                   <>
-                    {editingAnswer === cluster.id ? (
-                      <>
-                        <textarea
-                          className="hd-answer-input"
-                          placeholder="Add a follow-up response…"
-                          value={answers[cluster.id + "::followup"] ?? ""}
-                          onChange={e => onAnswerChange(cluster.id + "::followup", e.target.value)}
-                          rows={3}
-                        />
-                        <div className="hd-answer-btns">
-                          <button className="hd-btn-save" onClick={() => onSaveAnswer(cluster.id + "::followup")}>Save</button>
-                          <button className="hd-btn-cancel" onClick={() => onSetEditingAnswer(null)}>Cancel</button>
-                        </div>
-                      </>
-                    ) : (
-                      <button
-                        className="hd-btn-followup"
-                        onClick={() => onSetEditingAnswer(cluster.id)}
-                      >
-                        {answers[cluster.id] ? "+ Add follow-up response" : "Click to write a response…"}
+                    <textarea
+                      className="hd-answer-input"
+                      placeholder="Write a response to this cluster…"
+                      value={answers[cluster.id] ?? ""}
+                      onChange={e => onAnswerChange(cluster.id, e.target.value)}
+                      rows={3}
+                    />
+                    <div className="hd-answer-btns">
+                      <button className="hd-btn-save" onClick={() => onSaveAnswer(cluster.id)}>Save</button>
+                      <button className="hd-btn-cancel" onClick={() => onSetEditingAnswer(null)}>Cancel</button>
+                    </div>
+                  </>
+                ) : answers[cluster.id] ? (
+                  <div className="hd-answer-display has-answer">
+                    <span className="hd-answer-text">{answers[cluster.id]}</span>
+                    {phase === "RESULTS" && (
+                      <button className="hd-btn-edit-answer" onClick={() => onSetEditingAnswer(cluster.id)}>
+                        Edit
                       </button>
                     )}
-                  </>
+                  </div>
+                ) : (
+                  <div
+                    className="hd-answer-display no-answer"
+                    onClick={() => phase === "RESULTS" && onSetEditingAnswer(cluster.id)}
+                  >
+                    Click to write a response…
+                  </div>
                 )}
-
-              {answers[cluster.id + "::followup"] && editingAnswer !== cluster.id && (
-                <div className="hd-answer-display has-answer hd-answer-followup">
-                  <span className="hd-answer-label">A{i + 1}b.</span> {answers[cluster.id + "::followup"]}
-                </div>
-              )}
               </div>
 
             </div>

--- a/src/components/Host.jsx
+++ b/src/components/Host.jsx
@@ -89,6 +89,9 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     socket.on("cluster:answered", ({ clusterId, answer }) =>
       setAnswers(prev => ({ ...prev, [clusterId]: answer }))
     );
+    socket.on("cluster:followup:answered", ({ clusterId, answer }) =>
+      setAnswers(prev => ({ ...prev, [clusterId + "::followup"]: answer }))
+    );
     socket.on("participant:joined", ({ socketId, count }) => {
       setParticipantCount(count);
       setParticipants(prev => {
@@ -178,6 +181,9 @@ export default function HostDashboard({ code: initialCode, onBack }) {
       const savedPreviews = {};
       (data.clusters ?? []).forEach(c => {
         if (c.answer) savedAnswers[c.id] = c.answer;
+        if (c.participant_answers?.length) {
+          savedAnswers[c.id + "::followup"] = c.participant_answers[c.participant_answers.length - 1];
+        }
         if (c.selected_questions?.length) savedSelected[c.id] = new Set(c.selected_questions);
         if (c.previewed_questions?.length) savedPreviews[c.id] = { questions: c.previewed_questions, loading: false };
       });
@@ -382,7 +388,7 @@ export default function HostDashboard({ code: initialCode, onBack }) {
             onTagInput={setTagInput}
             onAddTag={addTag}
             onRemoveTag={removeTag}
-            canRecluster={submissionCount > submissionsAtLastCluster}
+            canRecluster={phase === "RESULTS"}
             onClose={closeSubmissions}
             onCluster={triggerClustering}
             onTriggerExpansion={openSecondRound}

--- a/src/components/Participant.jsx
+++ b/src/components/Participant.jsx
@@ -57,8 +57,13 @@ export default function Participant({ code, onBack }) {
     socket.on("cluster:deleted",   ({ clusterId }) =>
       setClusters(prev => prev.filter(c => c.id !== clusterId))
     );
-    socket.on("cluster:answered",  ({ clusterId, answer }) =>
-      setAnswers(prev => ({ ...prev, [clusterId]: answer }))
+    socket.on("cluster:answered", ({ clusterId, answer }) =>
+      /*
+      clusterId coming from the socket might be a number 
+      but cluster.id from the DB is a UUID string 
+      so answers[cluster.id] never matches.
+      */
+      setAnswers(prev => ({ ...prev, [String(clusterId)]: answer }))
     );
     socket.on("cluster:upvote",    ({ questionText, upvoteCount }) =>
       setClusters(prev => prev.map(c => ({

--- a/src/components/ParticipantCluster.jsx
+++ b/src/components/ParticipantCluster.jsx
@@ -187,7 +187,12 @@ export default function ParticipantClusterList({
         <ClusterCard
           key={cluster.id}
           cluster={cluster}
-          answer={answers[cluster.id]}
+          /*This way answers from the socket will 
+          match cluster.id from the DB, even if one is a number and the other is a string.
+          This should let them appear instantly when the host answers a cluster, 
+          without needing to refresh or wait for another update.
+          */
+          answer={answers[String(cluster.id)]}
           myTexts={myTexts}
           upvotes={upvotes}
           followups={followups?.[cluster.id]}


### PR DESCRIPTION
Improved host and participant experience across several areas. Hosts can now edit cluster answers in place without losing previous responses, and can update session tags during RESULTS and ENDED phases, not just OPEN. Clusters are numbered (Q1, Q2…) for easier reference during live sessions. Fixed a bug where participant answers weren't updating in real time without a page refresh, caused by a clusterId type mismatch on socket events. Removed the follow-up answer threading experiment in favour of a simpler single-answer-per-cluster model. Re-cluster button is now always available during RESULTS phase. Replaced the default Vite favicon with the PopularVote logo.