### PR TITLE
Replace hardcoded colors with CSS variables for dark mode support.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Home from './components/Home.jsx';
 import HostView from './components/Host.jsx';
 import Participant from './components/Participant.jsx';
@@ -7,6 +7,7 @@ import './App.css';
 export default function App() {
   const [view, setView] = useState(null);
 
+  // Sync theme/glass on every mount so all views get it
   function handleNavigate(role, code) {
     console.log("[handleNavigate]", role, code);
     setView({ role, code });

--- a/src/components/Home.css
+++ b/src/components/Home.css
@@ -1,5 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,700;1,400;1,500&family=DM+Mono:wght@300;400;500&display=swap');
 
+/* index.css */
 :root {
   --bg:           #f8f8f7;
   --surface:      #ffffff;

--- a/src/components/Host.css
+++ b/src/components/Host.css
@@ -2,9 +2,9 @@
 
 .hd-root {
   min-height: 100vh;
-  background: #f8f8f7;
-  font-family: 'EB Garamond', Georgia, serif;
-  color: #1c1917;
+  background: var(--bg);
+  font-family: var(--font-serif);
+  color: var(--text);
 }
 
 .hd-body {
@@ -23,16 +23,740 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f8f8f7;
+  background: var(--bg);
 }
 
 .hd-loading-text {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1.1rem;
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
   animation: pulse 1.5s ease infinite;
 }
 
 @keyframes spin  { to { transform: rotate(360deg); } }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+.hd-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  height: 56px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.hd-header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.hd-back {
+  background: none;
+  border: none;
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  color: var(--text-3);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s;
+}
+.hd-back:hover { color: var(--text); }
+
+.hd-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.hd-header-label {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.hd-phase {
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  font-weight: 500;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: 999px;
+}
+
+.hd-phase--open       { background: var(--green-bg); color: var(--green); }
+.hd-phase--closed     { background: var(--surface-sub); color: var(--text-2); }
+.hd-phase--clustering { background: var(--blue-bg); color: var(--blue); animation: pulse-badge 1.5s ease-in-out infinite; }
+.hd-phase--results    { background: var(--blue-bg); color: var(--blue); }
+.hd-phase--ended      { background: var(--surface-sub); color: var(--text-3); }
+
+@keyframes pulse-badge {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.55; }
+}
+
+.hd-header-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.hd-header-code {
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: var(--text-2);
+  background: var(--surface-sub);
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+.hd-header-stats {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.hd-hstat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+
+.hd-hstat-num {
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1;
+}
+
+.hd-hstat-label {
+  font-family: var(--font-serif);
+  font-size: 0.68rem;
+  font-style: italic;
+  color: var(--text-3);
+}
+
+.hd-stat-divider {
+  width: 1px;
+  height: 1.5rem;
+  background: var(--border);
+}
+
+.hd-sidebar-shell {
+  border-right: 1px solid var(--border);
+  background: var(--surface-sub);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow-y: auto;
+}
+
+.hd-sidebar {
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.hd-sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hd-sidebar-label {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+/* QR / share */
+.hd-qr-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.hd-qr-canvas {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 6px;
+}
+
+[data-theme="dark"] .hd-qr-canvas {
+  filter: invert(1);
+}
+
+.hd-share-link {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-3);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  width: 100%;
+  word-break: break-all;
+  line-height: 1.5;
+}
+
+.hd-copy-btn {
+  width: 100%;
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-style: italic;
+  color: var(--text-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.hd-copy-btn:hover { background: var(--surface-sub); border-color: var(--border-str); color: var(--text); }
+
+/* Tags */
+.hd-tags-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.hd-tag {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--text-2);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.hd-tag-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-3);
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0;
+  transition: color 0.15s;
+}
+.hd-tag-remove:hover { color: var(--red); }
+
+.hd-tag-input {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text);
+  width: 90px;
+}
+.hd-tag-input::placeholder { color: var(--text-3); }
+
+/* Action buttons */
+.hd-btn-action {
+  width: 100%;
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  font-style: italic;
+  background: var(--text);
+  color: var(--bg);
+  border: none;
+  border-radius: 8px;
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s, opacity 0.15s;
+}
+.hd-btn-action:hover:not(:disabled) { opacity: 0.88; }
+.hd-btn-action:active:not(:disabled) { transform: scale(0.99); }
+.hd-btn-action:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.hd-btn-danger {
+  width: 100%;
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-style: italic;
+  background: none;
+  color: var(--red);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.hd-btn-danger:hover { background: var(--delete-hover-bg); border-color: var(--red); }
+
+.hd-error {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--red);
+  line-height: 1.5;
+}
+
+.hd-participants {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.hd-participants-title {
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.hd-participant-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hd-participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px;
+  border-radius: 6px;
+  transition: background 0.12s;
+}
+.hd-participant-item:hover { background: var(--surface); }
+
+.hd-participant-id {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-2);
+}
+
+.hd-curator-badge {
+  font-family: var(--font-mono);
+  font-size: 0.52rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--blue);
+  background: var(--blue-bg);
+  border-radius: 999px;
+  padding: 1px 6px;
+}
+
+.hd-curator-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  color: var(--text-3);
+  transition: color 0.15s;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+.hd-curator-btn:hover { color: var(--blue); background: var(--blue-bg); }
+
+.hd-main {
+  padding: 1.5rem;
+  overflow-y: auto;
+  background: var(--bg);
+}
+
+.hd-clusters-empty {
+  text-align: center;
+  padding: 5rem 0;
+  color: var(--text-3);
+  font-style: italic;
+  font-size: 1rem;
+}
+
+.hd-clusters-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.875rem;
+}
+
+.hd-clusters-title {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hd-cluster {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: var(--sh-sm);
+  margin-bottom: 0.75rem;
+  transition: box-shadow 0.2s;
+}
+.hd-cluster:hover { box-shadow: var(--sh-md); }
+
+.hd-cluster-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+  gap: 1rem;
+}
+
+.hd-cluster-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hd-cluster-badge {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  background: var(--surface-sub);
+  color: var(--text-2);
+  border-radius: 999px;
+  padding: 2px 9px;
+}
+
+.hd-cluster-query {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.4;
+  margin-bottom: 0.75rem;
+}
+
+.hd-cluster-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.hd-btn-delete-cluster {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-3);
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s;
+}
+.hd-btn-delete-cluster:hover { color: var(--red); background: var(--delete-hover-bg); }
+.hd-btn-delete-cluster svg { width: 13px; height: 13px; }
+
+/* Questions list inside cluster */
+.hd-questions-list {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  border-top: 1px solid var(--border);
+}
+
+.hd-question-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+  color: var(--text-2);
+  line-height: 1.5;
+}
+
+.hd-upvote-count {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--text-3);
+  flex-shrink: 0;
+}
+
+/* Answer area */
+.hd-answer-wrap {
+  margin-top: 0.75rem;
+}
+
+.hd-answer-label {
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--green);
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.hd-answer-display {
+  background: var(--green-bg);
+  border: 1px solid var(--green-bd);
+  border-radius: 7px;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.95rem;
+  color: var(--text);
+  line-height: 1.6;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.hd-answer-display:hover { border-color: var(--green); }
+
+.hd-answer-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.625rem 0.875rem;
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  color: var(--text);
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  line-height: 1.6;
+  min-height: 80px;
+}
+.hd-answer-textarea:focus {
+  border-color: var(--text);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+.hd-answer-textarea::placeholder { color: var(--text-3); }
+
+.hd-answer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.hd-btn-save {
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-style: italic;
+  background: var(--text);
+  color: var(--bg);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.hd-btn-save:hover { opacity: 0.85; }
+
+.hd-btn-cancel {
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-style: italic;
+  background: none;
+  color: var(--text-2);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.hd-btn-cancel:hover { background: var(--surface-sub); border-color: var(--border-str); }
+
+.hd-btn-edit-answer {
+  font-family: var(--font-serif);
+  font-size: 0.8rem;
+  font-style: italic;
+  background: none;
+  color: var(--text-3);
+  border: 1px dashed var(--border);
+  border-radius: 7px;
+  padding: 0.45rem 1rem;
+  width: 100%;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  text-align: left;
+}
+.hd-btn-edit-answer:hover { color: var(--text); border-color: var(--border-str); }
+
+/* Clustering spinner */
+.hd-clustering-wrap {
+  text-align: center;
+  padding: 5rem 0;
+}
+
+.hd-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--border);
+  border-top-color: var(--text);
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  margin: 0 auto 1.25rem;
+}
+
+.hd-clustering-title {
+  font-family: var(--font-serif);
+  font-size: 1.35rem;
+  font-style: italic;
+  color: var(--text);
+  margin-bottom: 0.375rem;
+}
+
+.hd-clustering-sub {
+  font-size: 0.95rem;
+  color: var(--text-3);
+  max-width: 340px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Expand / preview */
+.hd-expand-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  color: var(--text-3);
+  padding: 0;
+  margin-bottom: 0.5rem;
+  transition: color 0.15s;
+}
+.hd-expand-btn:hover { color: var(--text); }
+
+.hd-preview-questions {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hd-preview-q {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-style: italic;
+  color: var(--text-2);
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.hd-preview-q:hover { background: var(--surface); border-color: var(--border-str); }
+.hd-preview-q--selected {
+  background: var(--blue-bg);
+  border-color: var(--blue-bd);
+  color: var(--blue);
+  font-style: normal;
+}
+
+/* manual question input */
+.hd-manual-input-wrap {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.hd-manual-input {
+  flex: 1;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  padding: 0.4rem 0.75rem;
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  color: var(--text);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.hd-manual-input:focus {
+  border-color: var(--text);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+.hd-manual-input::placeholder { color: var(--text-3); }
+
+.hd-manual-submit {
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-style: italic;
+  background: var(--text);
+  color: var(--bg);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+.hd-manual-submit:hover { opacity: 0.85; }
+
+/* ─── Glass mode ─────────────────────────────────────────────────────────── */
+
+[data-glass="on"] .hd-header {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+
+[data-glass="on"] .hd-sidebar-shell {
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-right-color: rgba(255, 255, 255, 0.12);
+}
+
+[data-glass="on"] .hd-cluster {
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+[data-glass="on"][data-theme="dark"] .hd-header {
+  background: rgba(0, 0, 0, 0.3);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-glass="on"][data-theme="dark"] .hd-sidebar-shell {
+  background: rgba(0, 0, 0, 0.25);
+  border-right-color: rgba(255, 255, 255, 0.06);
+}
+
+[data-glass="on"][data-theme="dark"] .hd-cluster {
+  background: rgba(0, 0, 0, 0.25);
+  border-color: rgba(255, 255, 255, 0.07);
+}

--- a/src/components/Host.jsx
+++ b/src/components/Host.jsx
@@ -9,6 +9,7 @@ import ClusterList from "./ClusterList";
 import "./Host.css";
 
 export default function HostDashboard({ code: initialCode, onBack }) {
+  // Core session state
   const [phase, setPhase] = useState("OPEN");
   const [code, setCode] = useState(initialCode);
   const [tags, setTags] = useState([]);
@@ -24,20 +25,21 @@ export default function HostDashboard({ code: initialCode, onBack }) {
   const [answers, setAnswers] = useState({});
   const [editingAnswer, setEditingAnswer] = useState(null);
 
-  // expansion state
+  // Expansion state
   const [expansionPreviews, setExpansionPreviews] = useState({});
   const [selectedQuestions, setSelectedQuestions] = useState({});
   const [manualQuestions, setManualQuestions] = useState({});
   const [expandLoading, setExpandLoading] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
 
-  // curator state
+  // Curator / participant state
   const [participants, setParticipants] = useState([]);
   const [curators, setCurators] = useState([]);
 
   const socketRef = useRef(null);
   const createdRef = useRef(false);
 
+  // Initialize session
   useEffect(() => {
     if (initialCode === "NEW") {
       if (createdRef.current) return;
@@ -48,6 +50,7 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     }
   }, []);
 
+  // Socket connection and real-time listeners
   useEffect(() => {
     if (!code || code === "NEW") return;
 
@@ -66,6 +69,7 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     socket.on("submission:new", ({ id, content }) => {
       setSubmissions(prev => [...prev, { id, content }]);
     });
+
     socket.on("session:closed", () => setPhase("CLOSED"));
     socket.on("session:clustering", () => setPhase("CLUSTERING"));
     socket.on("session:results", ({ clusters, submissionsAtLastCluster }) => {
@@ -73,25 +77,31 @@ export default function HostDashboard({ code: initialCode, onBack }) {
       if (submissionsAtLastCluster !== undefined) setSubmissionsAtLastCluster(submissionsAtLastCluster);
       setPhase("RESULTS");
     });
+
     socket.on("cluster:upvote", ({ questionText, upvoteCount }) => {
-      setClusters(prev => prev.map(c => ({
-        ...c,
-        questions: c.questions?.map(q =>
-          q.text === questionText ? { ...q, upvoteCount } : q
-        ),
-      })));
+      setClusters(prev =>
+        prev.map(c => ({
+          ...c,
+          questions: c.questions?.map(q =>
+            q.text === questionText ? { ...q, upvoteCount } : q
+          ),
+        }))
+      );
     });
-    
+
     socket.on("session:ended", () => setPhase("ENDED"));
     socket.on("cluster:deleted", ({ clusterId }) =>
       setClusters(prev => prev.filter(c => c.id !== clusterId))
     );
+
     socket.on("cluster:answered", ({ clusterId, answer }) =>
       setAnswers(prev => ({ ...prev, [clusterId]: answer }))
     );
+
     socket.on("cluster:followup:answered", ({ clusterId, answer }) =>
       setAnswers(prev => ({ ...prev, [clusterId + "::followup"]: answer }))
     );
+
     socket.on("participant:joined", ({ socketId, count }) => {
       setParticipantCount(count);
       setParticipants(prev => {
@@ -99,18 +109,21 @@ export default function HostDashboard({ code: initialCode, onBack }) {
         return [...prev, { socketId, isCurator: false }];
       });
     });
+
     socket.on("participant:left", ({ socketId, count }) => {
       setParticipantCount(count);
       setParticipants(prev => prev.filter(p => p.socketId !== socketId));
     });
+
     socket.on("curator:updated", ({ curators: newCurators }) => {
       setCurators(newCurators);
       setParticipants(prev =>
         prev.map(p => ({ ...p, isCurator: newCurators.includes(p.socketId) }))
       );
     });
-    socket.on("expansion:preview", ({ clusterPreviews, contextualFacts }) => {
-      console.log("[socket] expansion:preview received", { clusterPreviews, contextualFacts });
+
+    socket.on("expansion:preview", ({ clusterPreviews }) => {
+      console.log("[socket] expansion:preview received", { clusterPreviews });
       setExpansionPreviews(prev => {
         const next = { ...prev };
         clusterPreviews.forEach(({ clusterId, previewedQuestions }) => {
@@ -125,23 +138,33 @@ export default function HostDashboard({ code: initialCode, onBack }) {
 
     socket.on("cluster:submission:added", ({ clusterId, question, submissionCount }) => {
       console.log("[cluster:submission:added]", { clusterId, question, submissionCount });
-      setClusters(prev => prev.map(c => {
-        if (String(c.id) !== String(clusterId)) return c;
-        return {
-          ...c,
-          submission_count: submissionCount,
-          questions: [...(c.questions ?? []), question],
-        };
-      }));
+      setClusters(prev =>
+        prev.map(c => {
+          if (String(c.id) !== String(clusterId)) return c;
+          return {
+            ...c,
+            submission_count: submissionCount,
+            questions: [...(c.questions ?? []), question],
+          };
+        })
+      );
     });
 
     // host triggered delete — navigate away
-    socket.on("session:deleted", () => {
-      onBack();
-    });
+    socket.on("session:deleted", () => onBack());
 
     return () => socket.disconnect();
   }, [code]);
+
+  // Theme setup
+  useEffect(() => {
+    const dark = localStorage.getItem("pv-dark") === "true";
+    const glass = localStorage.getItem("pv-glass") === "true";
+    document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
+    document.documentElement.setAttribute("data-glass", glass ? "on" : "off");
+  }, []);
+
+  // ====================== API & Session Management ======================
 
   async function createSession() {
     setLoading(true);
@@ -153,6 +176,7 @@ export default function HostDashboard({ code: initialCode, onBack }) {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
+
       setCode(data.code);
       setPhase(data.phase);
       setTags(data.tags ?? []);
@@ -167,7 +191,9 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     try {
       const res = await fetch(`/api/sessions/${initialCode}`);
       if (!res.ok) throw new Error("Session not found");
+
       const data = await res.json();
+
       setPhase(data.phase);
       setTags(data.tags ?? []);
       setSubmissions(data.submissions ?? []);
@@ -176,17 +202,24 @@ export default function HostDashboard({ code: initialCode, onBack }) {
       setParticipantCount(data.participantCount ?? 0);
       setClusters(data.clusters ?? []);
       setCurators(data.curators ?? []);
+
       const savedAnswers = {};
       const savedSelected = {};
       const savedPreviews = {};
+
       (data.clusters ?? []).forEach(c => {
         if (c.answer) savedAnswers[c.id] = c.answer;
         if (c.participant_answers?.length) {
           savedAnswers[c.id + "::followup"] = c.participant_answers[c.participant_answers.length - 1];
         }
-        if (c.selected_questions?.length) savedSelected[c.id] = new Set(c.selected_questions);
-        if (c.previewed_questions?.length) savedPreviews[c.id] = { questions: c.previewed_questions, loading: false };
+        if (c.selected_questions?.length) {
+          savedSelected[c.id] = new Set(c.selected_questions);
+        }
+        if (c.previewed_questions?.length) {
+          savedPreviews[c.id] = { questions: c.previewed_questions, loading: false };
+        }
       });
+
       setAnswers(savedAnswers);
       setSelectedQuestions(savedSelected);
       setExpansionPreviews(savedPreviews);
@@ -194,6 +227,8 @@ export default function HostDashboard({ code: initialCode, onBack }) {
       setError("Could not load session.");
     }
   }
+
+  // ====================== Actions ======================
 
   async function closeSubmissions() {
     setActionLoading(true);
@@ -210,14 +245,19 @@ export default function HostDashboard({ code: initialCode, onBack }) {
   }
 
   async function triggerClustering() {
-    if (submissionCount === 0) { setError("No submissions yet."); return; }
+    if (submissionCount === 0) {
+      setError("No submissions yet.");
+      return;
+    }
     setActionLoading(true);
     setError("");
     setPhase("CLUSTERING");
+
     try {
       const res = await fetch(`/api/sessions/${code}/cluster`, { method: "POST" });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
+
       setClusters(data.clusters);
       setPhase("RESULTS");
     } catch (err) {
@@ -256,10 +296,12 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     const [clusterId, question] = answerId.includes("::")
       ? answerId.split("::")
       : [answerId, null];
+
     try {
       const url = question
         ? `/api/sessions/${code}/clusters/${clusterId}/answer?question=${encodeURIComponent(question)}`
         : `/api/sessions/${code}/clusters/${clusterId}/answer`;
+
       await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -306,7 +348,6 @@ export default function HostDashboard({ code: initialCode, onBack }) {
     }
   }
 
-  // promote or demote a participant as curator
   async function toggleCurator(socketId) {
     try {
       const res = await fetch(`/api/sessions/${code}/curators`, {
@@ -316,6 +357,7 @@ export default function HostDashboard({ code: initialCode, onBack }) {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
+
       setCurators(data.curators);
       setParticipants(prev =>
         prev.map(p => ({ ...p, isCurator: data.curators.includes(p.socketId) }))
@@ -328,14 +370,16 @@ export default function HostDashboard({ code: initialCode, onBack }) {
   async function saveTags(updatedTags) {
     try {
       await fetch(`/api/sessions/${code}/tags`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ tags: updatedTags }),
       });
     } catch (err) {
-      console.error('Failed to save tags:', err);
+      console.error("Failed to save tags:", err);
     }
   }
+
+  // ====================== UI Handlers ======================
 
   function addTag(e) {
     if ((e.key === "Enter" || e.key === ",") && tagInput.trim()) {

--- a/src/components/HostSidebar.css
+++ b/src/components/HostSidebar.css
@@ -1,10 +1,10 @@
 .hd-sidebar {
-  border-right: 1px solid #e5e4e1;
+  border-right: 1px solid var(--border);
   padding: 1.25rem 1rem;
   display: flex;
   flex-direction: column;
   gap: 0;
-  background: #ffffff;
+  background: var(--surface);
   overflow-y: auto;
 }
 
@@ -13,7 +13,7 @@
   flex-direction: column;
   gap: 0.625rem;
   padding: 1rem 0;
-  border-bottom: 1px solid #f0efec;
+  border-bottom: 1px solid var(--border);
 }
 .hd-card:last-child { border-bottom: none; }
 
@@ -23,7 +23,7 @@
   font-weight: 500;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #a8a29e;
+  color: var(--text-3);
 }
 
 .hd-code {
@@ -31,10 +31,10 @@
   font-size: 1.75rem;
   font-weight: 500;
   letter-spacing: 0.2em;
-  color: #1c1917;
+  color: var(--text);
   line-height: 1;
-  background: #f8f8f7;
-  border: 1px solid #e5e4e1;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.625rem 0.75rem;
   text-align: center;
@@ -48,7 +48,7 @@
 .hd-url {
   font-family: 'DM Mono', monospace;
   font-size: 0.55rem;
-  color: #a8a29e;
+  color: var(--text-3);
   word-break: break-all;
   line-height: 1.4;
 }
@@ -56,10 +56,14 @@
 .hd-qr-canvas {
   display: block;
   margin: 0 auto;
-  border: 1px solid #e5e4e1;
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 6px;
-  background: #ffffff;
+  background: var(--surface);
+}
+
+[data-theme="dark"] .hd-qr-canvas {
+  filter: invert(1);
 }
 
 .hd-tags {
@@ -75,60 +79,60 @@
   font-family: 'EB Garamond', serif;
   font-size: 0.82rem;
   font-style: italic;
-  color: #57534e;
-  background: #f5f4f2;
+  color: var(--text-2);
+  background: var(--surface-sub);
   padding: 2px 9px;
-  border: 1px solid #e5e4e1;
+  border: 1px solid var(--border);
   border-radius: 999px;
 }
 
 .hd-tag-remove {
   background: none;
   border: none;
-  color: #a8a29e;
+  color: var(--text-3);
   cursor: pointer;
   font-size: 0.85rem;
   line-height: 1;
   padding: 0;
   transition: color 0.15s;
 }
-.hd-tag-remove:hover { color: #dc2626; }
+.hd-tag-remove:hover { color: var(--red); }
 
 .hd-tag-input {
   width: 100%;
-  background: #f8f8f7;
-  border: 1px solid #e5e4e1;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 7px;
   font-family: 'EB Garamond', serif;
   font-size: 0.9rem;
   font-style: italic;
-  color: #1c1917;
+  color: var(--text);
   padding: 6px 10px;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .hd-tag-input:focus {
-  border-color: #1c1917;
-  box-shadow: 0 0 0 3px rgba(28, 25, 23, 0.07);
+  border-color: var(--text);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
-.hd-tag-input::placeholder { color: #a8a29e; }
+.hd-tag-input::placeholder { color: var(--text-3); }
 
 .hd-btn-ghost {
-  background: #ffffff;
-  border: 1px solid #e5e4e1;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 7px;
   font-family: 'EB Garamond', serif;
   font-size: 0.875rem;
   font-style: italic;
-  color: #57534e;
+  color: var(--text-2);
   cursor: pointer;
   padding: 5px 12px;
   transition: border-color 0.15s, color 0.15s, background 0.15s;
 }
 .hd-btn-ghost:hover {
-  border-color: #1c1917;
-  color: #1c1917;
-  background: #f8f8f7;
+  border-color: var(--border-str);
+  color: var(--text);
+  background: var(--surface-sub);
 }
 
 .hd-btn-ghost--full { width: 100%; padding: 0.6rem 1rem; font-size: 0.975rem; }
@@ -142,37 +146,32 @@
   cursor: pointer;
   border: none;
   border-radius: 8px;
-  background: #1c1917;
-  color: #ffffff;
+  background: var(--text);
+  color: var(--bg);
   transition: background 0.15s, transform 0.1s;
 }
-.hd-btn-primary:hover:not(:disabled) { background: #2c2925; }
+.hd-btn-primary:hover:not(:disabled) { opacity: 0.88; }
 .hd-btn-primary:active:not(:disabled) { transform: scale(0.99); }
-.hd-btn-primary:disabled { background: #e5e4e1; color: #a8a29e; cursor: not-allowed; }
+.hd-btn-primary:disabled { background: var(--border); color: var(--text-3); cursor: not-allowed; }
 
 .hd-btn-expand {
-  background: #1d4ed8;
+  background: var(--blue);
 }
-.hd-btn-expand:hover:not(:disabled) { background: #1e40af; }
+.hd-btn-expand:hover:not(:disabled) { opacity: 0.88; }
 
 .hd-btn-end {
   width: 100%;
-  padding: 0.6rem 1rem;
-  font-family: 'EB Garamond', serif;
-  font-size: 0.975rem;
-  font-style: italic;
-  cursor: pointer;
-  border: 1px solid #fca5a5;
-  border-radius: 8px;
-  background: transparent;
-  color: #dc2626;
-  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.1s;
-}
-.hd-btn-end:hover:not(:disabled) {
-  background: #dc2626;
+  padding: 0.65rem 1rem;
+  background: var(--red);
   color: #fff;
-  border-color: #dc2626;
+  border: none;
+  border-radius: 8px;
+  font-family: 'EB Garamond', serif;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s, transform 0.1s;
 }
+.hd-btn-end:hover:not(:disabled) { opacity: 0.88; }
 .hd-btn-end:active:not(:disabled) { transform: scale(0.99); }
 .hd-btn-end:disabled { opacity: 0.35; cursor: not-allowed; }
 
@@ -180,9 +179,9 @@
   font-family: 'EB Garamond', serif;
   font-size: 0.875rem;
   font-style: italic;
-  color: #dc2626;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  color: var(--red);
+  background: var(--delete-hover-bg);
+  border: 1px solid var(--red);
   border-radius: 7px;
   padding: 6px 10px;
   line-height: 1.5;
@@ -195,14 +194,14 @@
   font-family: 'EB Garamond', serif;
   font-size: 0.875rem;
   font-style: italic;
-  color: #57534e;
+  color: var(--text-2);
 }
 
 .hd-spinner {
   width: 13px;
   height: 13px;
-  border: 2px solid #e5e4e1;
-  border-top-color: #1c1917;
+  border: 2px solid var(--border);
+  border-top-color: var(--text);
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
   flex-shrink: 0;
@@ -214,29 +213,7 @@
   font-family: 'EB Garamond', serif;
   font-size: 0.875rem;
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
   text-align: center;
   padding: 0.25rem 0;
-}
-
-.hd-btn-end {
-  width: 100%;
-  padding: 0.65rem 1rem;
-  background: #dc2626;
-  color: #fff;
-  border: none;
-  border-radius: 8px;
-  font-family: 'EB Garamond', serif;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.hd-btn-end:hover {
-  background: #b91c1c;
-}
-
-.hd-btn-end:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }

--- a/src/components/Participant.css
+++ b/src/components/Participant.css
@@ -2,9 +2,9 @@
 
 .pd-root {
   min-height: 100vh;
-  background: #f8f8f7;
-  font-family: 'EB Garamond', serif;
-  color: #1c1917;
+  background: var(--bg);
+  font-family: var(--font-serif);
+  color: var(--text);
 }
 
 .pd-header {
@@ -13,8 +13,8 @@
   justify-content: space-between;
   padding: 0 2rem;
   height: 56px;
-  background: #ffffff;
-  border-bottom: 1px solid #e5e4e1;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
   z-index: 50;
@@ -29,14 +29,14 @@
 .pd-back {
   background: none;
   border: none;
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.9rem;
-  color: #a8a29e;
+  color: var(--text-3);
   cursor: pointer;
   padding: 0;
   transition: color 0.15s;
 }
-.pd-back:hover { color: #1c1917; }
+.pd-back:hover { color: var(--text); }
 
 .pd-header-meta {
   display: flex;
@@ -45,14 +45,14 @@
 }
 
 .pd-header-label {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1rem;
   font-weight: 700;
-  color: #1c1917;
+  color: var(--text);
 }
 
 .pd-phase {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.56rem;
   font-weight: 500;
   letter-spacing: 0.07em;
@@ -62,11 +62,11 @@
   border: none;
 }
 
-.pd-phase--open       { background: #f0fdf4; color: #15803d; }
-.pd-phase--closed     { background: #f5f4f2; color: #57534e; }
-.pd-phase--clustering { background: #eff6ff; color: #1d4ed8; animation: pulse-badge 1.5s ease-in-out infinite; }
-.pd-phase--results    { background: #eff6ff; color: #1d4ed8; }
-.pd-phase--ended      { background: #f5f4f2; color: #a8a29e; }
+.pd-phase--open       { background: var(--green-bg);   color: var(--green); }
+.pd-phase--closed     { background: var(--surface-sub); color: var(--text-2); }
+.pd-phase--clustering { background: var(--blue-bg);    color: var(--blue); animation: pulse-badge 1.5s ease-in-out infinite; }
+.pd-phase--results    { background: var(--blue-bg);    color: var(--blue); }
+.pd-phase--ended      { background: var(--surface-sub); color: var(--text-3); }
 
 @keyframes pulse-badge {
   0%, 100% { opacity: 1; }
@@ -80,14 +80,15 @@
 }
 
 .pd-header-code {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.875rem;
   font-weight: 500;
   letter-spacing: 0.12em;
-  color: #57534e;
-  background: #f5f4f2;
+  color: var(--text-2);
+  background: var(--surface-sub);
   padding: 4px 10px;
   border-radius: 6px;
+  border: 1px solid var(--border);
 }
 
 .pd-header-stats {
@@ -104,18 +105,18 @@
 }
 
 .pd-hstat-num {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 1.1rem;
   font-weight: 500;
-  color: #1c1917;
+  color: var(--text);
   line-height: 1;
 }
 
 .pd-hstat-label {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.68rem;
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
 }
 
 .pd-body {
@@ -128,11 +129,11 @@
 }
 
 .pd-card {
-  background: #ffffff;
-  border: 1px solid #e5e4e1;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 10px;
   padding: 1.375rem 1.5rem;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  box-shadow: var(--sh-sm);
 }
 
 .pd-card--submissions { padding: 1.125rem 1.5rem; }
@@ -146,17 +147,17 @@
 }
 
 .pd-card-title {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1.15rem;
   font-weight: 700;
-  color: #1c1917;
+  color: var(--text);
 }
 
 .pd-card-title--sm {
   font-size: 0.9rem;
   font-weight: 700;
   margin-bottom: 0.5rem;
-  color: #57534e;
+  color: var(--text-2);
 }
 
 .pd-stats-row {
@@ -173,47 +174,47 @@
 }
 
 .pd-stat-num {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 1.1rem;
   font-weight: 500;
-  color: #1c1917;
+  color: var(--text);
   line-height: 1;
 }
 
 .pd-stat-label {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.68rem;
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
 }
 
 .pd-stat-divider {
   width: 1px;
   height: 1.5rem;
-  background: #e5e4e1;
+  background: var(--border);
 }
 
 .pd-textarea {
   width: 100%;
   box-sizing: border-box;
-  background: #f8f8f7;
-  border: 1px solid #e5e4e1;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.75rem 1rem;
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1rem;
-  color: #1c1917;
+  color: var(--text);
   resize: none;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
   line-height: 1.6;
 }
 .pd-textarea:focus {
-  border-color: #1c1917;
-  box-shadow: 0 0 0 3px rgba(28, 25, 23, 0.07);
+  border-color: var(--text);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
-.pd-textarea::placeholder { color: #a8a29e; }
-.pd-textarea:disabled { background: #f5f4f2; color: #a8a29e; cursor: not-allowed; }
+.pd-textarea::placeholder { color: var(--text-3); }
+.pd-textarea:disabled { color: var(--text-3); cursor: not-allowed; }
 .pd-textarea--sm { margin-top: 0.625rem; }
 
 .pd-textarea-footer {
@@ -224,58 +225,59 @@
 }
 
 .pd-charcount {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.65rem;
-  color: #a8a29e;
+  color: var(--text-3);
 }
-.pd-charcount--warn { color: #c2410c; }
+.pd-charcount--warn { color: var(--accent); }
 
 .pd-btn-primary {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.95rem;
   font-weight: 600;
-  background: #1c1917;
-  color: #ffffff;
+  background: var(--text);
+  color: var(--bg);
   border: none;
   border-radius: 7px;
   padding: 0.45rem 1.25rem;
   cursor: pointer;
-  transition: background 0.15s, transform 0.1s;
+  transition: opacity 0.15s, transform 0.1s;
 }
-.pd-btn-primary:hover:not(:disabled) { background: #2c2925; }
+.pd-btn-primary:hover:not(:disabled) { opacity: 0.85; }
 .pd-btn-primary:active:not(:disabled) { transform: scale(0.99); }
-.pd-btn-primary:disabled { background: #e5e4e1; color: #a8a29e; cursor: not-allowed; }
+.pd-btn-primary:disabled { background: var(--border); color: var(--text-3); cursor: not-allowed; }
 
 .pd-btn-ghost {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.95rem;
-  color: #57534e;
+  color: var(--text-2);
   background: none;
-  border: 1px solid #e5e4e1;
+  border: 1px solid var(--border);
   border-radius: 7px;
   padding: 0.45rem 1rem;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
 }
-.pd-btn-ghost:hover { color: #1c1917; border-color: #1c1917; }
+.pd-btn-ghost:hover { color: var(--text); border-color: var(--border-str); }
 
 .pd-closed-msg {
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
   font-size: 0.95rem;
   margin: 0.25rem 0 0;
   line-height: 1.6;
 }
 
 .pd-error {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.7rem;
-  color: #dc2626;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
+  color: var(--red);
+  background: var(--delete-hover-bg);
+  border: 1px solid var(--red);
   border-radius: 7px;
   padding: 0.5rem 0.75rem;
   margin-top: 0.625rem;
+  opacity: 0.85;
 }
 
 .pd-submissions-list {
@@ -290,13 +292,13 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 0.5rem 0;
-  border-bottom: 1px solid #f5f4f2;
+  border-bottom: 1px solid var(--border);
 }
 .pd-submission-item:last-child { border-bottom: none; }
 
 .pd-submission-text {
   font-size: 0.95rem;
-  color: #57534e;
+  color: var(--text-2);
   line-height: 1.5;
   flex: 1;
 }
@@ -305,7 +307,7 @@
   background: none;
   border: none;
   cursor: pointer;
-  color: #d4d2ce;
+  color: var(--text-3);
   font-size: 1rem;
   line-height: 1;
   padding: 2px 4px;
@@ -313,7 +315,7 @@
   transition: color 0.15s, background 0.15s;
   flex-shrink: 0;
 }
-.pd-delete-btn:hover { color: #dc2626; background: rgba(220,38,38,0.07); }
+.pd-delete-btn:hover { color: var(--red); background: var(--delete-hover-bg); }
 
 .pd-waiting {
   text-align: center;
@@ -323,8 +325,8 @@
 .pd-spinner {
   width: 24px;
   height: 24px;
-  border: 2px solid #e5e4e1;
-  border-top-color: #1c1917;
+  border: 2px solid var(--border);
+  border-top-color: var(--text);
   border-radius: 50%;
   animation: pd-spin 0.75s linear infinite;
   margin: 0 auto 1.25rem;
@@ -333,55 +335,53 @@
 @keyframes pd-spin { to { transform: rotate(360deg); } }
 
 .pd-waiting-title {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1.35rem;
   font-style: italic;
-  color: #1c1917;
+  color: var(--text);
   margin-bottom: 0.375rem;
 }
 
 .pd-waiting-sub {
   font-size: 0.95rem;
-  color: #a8a29e;
+  color: var(--text-3);
   max-width: 340px;
   margin: 0 auto;
   line-height: 1.6;
 }
 
 .pd-ended-banner {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.65rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #57534e;
-  background: #f5f4f2;
-  border: 1px solid #e5e4e1;
+  color: var(--text-2);
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 0.75rem 1rem;
   text-align: center;
 }
 
-/* ─── Round 2 ────────────────────────────────────────────────────────────── */
-
 .pd-round2-banner {
-  background: #f0f4ff;
-  border: 1px solid #c7d2fe;
+  background: var(--blue-bg);
+  border: 1px solid var(--blue-bd);
   border-radius: 10px;
   padding: 1rem 1.25rem;
   margin-bottom: 1.25rem;
 }
 
 .pd-round2-title {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1.1rem;
   font-weight: 600;
-  color: #1e40af;
+  color: var(--blue);
   margin-bottom: 0.25rem;
 }
 
 .pd-round2-sub {
   font-size: 0.9rem;
-  color: #3730a3;
+  color: var(--text-2);
   line-height: 1.55;
   margin: 0;
 }
@@ -391,11 +391,11 @@
 }
 
 .pd-prompts-label {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.62rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #a8a29e;
+  color: var(--text-3);
   margin-bottom: 0.625rem;
 }
 
@@ -409,12 +409,12 @@
 }
 
 .pd-prompt-item {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.95rem;
   font-style: italic;
-  color: #57534e;
-  background: #f8f8f7;
-  border: 1px solid #e5e4e1;
+  color: var(--text-2);
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 7px;
   padding: 0.5rem 0.875rem;
   line-height: 1.5;
@@ -428,25 +428,25 @@
 }
 
 .pd-clusters-title {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.62rem;
-  color: #a8a29e;
+  color: var(--text-3);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
 .pd-cluster {
-  background: #ffffff;
-  border: 1px solid #e5e4e1;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 10px;
   padding: 1.25rem 1.5rem;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  box-shadow: var(--sh-sm);
   transition: box-shadow 0.2s;
   margin-bottom: 0.75rem;
 }
-.pd-cluster:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.07); }
+.pd-cluster:hover { box-shadow: var(--sh-md); }
 
-.pd-cluster--mine { border-left: 3px solid #1d4ed8; }
+.pd-cluster--mine { border-left: 3px solid var(--blue); }
 
 .pd-cluster-top {
   display: flex;
@@ -462,53 +462,53 @@
 }
 
 .pd-cluster-badge {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.6rem;
   font-weight: 500;
   letter-spacing: 0.05em;
-  background: #f5f4f2;
-  color: #57534e;
+  background: var(--surface-sub);
+  color: var(--text-2);
   border-radius: 999px;
   padding: 2px 9px;
 }
 
 .pd-cluster-mine-tag {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.78rem;
   font-style: italic;
-  color: #1d4ed8;
+  color: var(--blue);
 }
 
 .pd-cluster-query {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1.1rem;
   font-weight: 600;
-  color: #1c1917;
+  color: var(--text);
   line-height: 1.4;
   margin-bottom: 0.75rem;
 }
 
 .pd-cluster-answer {
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
+  background: var(--green-bg);
+  border: 1px solid var(--green-bd);
   border-radius: 7px;
   padding: 0.625rem 0.875rem;
   margin-bottom: 0.75rem;
 }
 
 .pd-answer-label {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.56rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: #15803d;
+  color: var(--green);
   display: block;
   margin-bottom: 0.25rem;
 }
 
 .pd-answer-text {
   font-size: 0.95rem;
-  color: #1c4f2a;
+  color: var(--text);
   line-height: 1.6;
   margin: 0;
 }
@@ -517,21 +517,21 @@
   background: none;
   border: none;
   cursor: pointer;
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.6rem;
   letter-spacing: 0.06em;
-  color: #a8a29e;
+  color: var(--text-3);
   padding: 0;
   margin-bottom: 0.5rem;
   transition: color 0.15s;
 }
-.pd-expand-btn:hover { color: #1c1917; }
+.pd-expand-btn:hover { color: var(--text); }
 
 .pd-questions-list {
   list-style: none;
   margin: 0 0 0.75rem;
   padding: 0;
-  border-top: 1px solid #f5f4f2;
+  border-top: 1px solid var(--border);
 }
 
 .pd-question-item {
@@ -540,13 +540,13 @@
   justify-content: space-between;
   gap: 0.75rem;
   padding: 0.45rem 0;
-  border-bottom: 1px solid #f5f4f2;
+  border-bottom: 1px solid var(--border);
   font-size: 0.9rem;
-  color: #57534e;
+  color: var(--text-2);
   line-height: 1.5;
 }
 
-.pd-question-item--own { color: #1d4ed8; }
+.pd-question-item--own { color: var(--blue); }
 
 .pd-question-text {
   display: flex;
@@ -559,45 +559,44 @@
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: #1d4ed8;
+  background: var(--blue);
   flex-shrink: 0;
 }
 
 .pd-upvote-btn {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.6rem;
   letter-spacing: 0.04em;
-  background: #f5f4f2;
-  border: 1px solid #e5e4e1;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  color: #57534e;
+  color: var(--text-2);
   padding: 2px 9px;
   cursor: pointer;
   transition: all 0.15s;
   flex-shrink: 0;
 }
-.pd-upvote-btn:hover { border-color: #1c1917; color: #1c1917; background: #ebebea; }
+.pd-upvote-btn:hover { border-color: var(--border-str); color: var(--text); background: var(--surface); }
 .pd-upvote-btn--voted {
-  background: #1c1917;
-  border-color: #1c1917;
-  color: #ffffff;
+  background: var(--text);
+  border-color: var(--text);
+  color: var(--bg);
 }
 
 .pd-upvote-count {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.6rem;
-  color: #a8a29e;
+  color: var(--text-3);
   flex-shrink: 0;
 }
 
-
 .pd-add-q-btn {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.875rem;
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
   background: none;
-  border: 1px dashed #d4d2ce;
+  border: 1px dashed var(--border-str);
   border-radius: 7px;
   padding: 0.45rem 1rem;
   width: 100%;
@@ -605,7 +604,7 @@
   transition: color 0.15s, border-color 0.15s;
   text-align: left;
 }
-.pd-add-q-btn:hover { color: #1c1917; border-color: #a8a29e; }
+.pd-add-q-btn:hover { color: var(--text); border-color: var(--text); }
 
 .pd-cluster-input-area { margin-top: 0.5rem; }
 
@@ -615,10 +614,10 @@
 }
 
 .pd-empty-title {
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 1.05rem;
   font-style: italic;
-  color: #a8a29e;
+  color: var(--text-3);
 }
 
 .pd-input-shell {
@@ -627,28 +626,18 @@
   gap: 0.75rem;
 }
 
-@media (max-width: 640px) {
-  .pd-header { padding: 0 1rem; }
-  .pd-header-code { display: none; }
-  .pd-body { padding: 1.25rem 0.875rem; }
-  .pd-card { padding: 1.125rem 1.25rem; }
-  .pd-cluster { padding: 1rem 1.125rem; }
-}
-
-/* ─── Follow-up suggestions ──────────────────────────────────────────────── */
-
 .pd-followups {
   margin-top: 0.875rem;
   padding-top: 0.875rem;
-  border-top: 1px solid #f0efec;
+  border-top: 1px solid var(--border);
 }
 
 .pd-followups-label {
-  font-family: 'DM Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.6rem;
   letter-spacing: 0.07em;
   text-transform: uppercase;
-  color: #a8a29e;
+  color: var(--text-3);
   margin-bottom: 0.5rem;
 }
 
@@ -664,39 +653,70 @@
 .pd-followup-chip {
   width: 100%;
   text-align: left;
-  background: #f8f8f7;
-  border: 1px solid #e5e4e1;
+  background: var(--surface-sub);
+  border: 1px solid var(--border);
   border-radius: 7px;
   padding: 0.5rem 0.875rem;
-  font-family: 'EB Garamond', serif;
+  font-family: var(--font-serif);
   font-size: 0.95rem;
   font-style: italic;
-  color: #57534e;
+  color: var(--text-2);
   cursor: pointer;
   transition: border-color 0.15s, background 0.15s, color 0.15s;
   line-height: 1.45;
 }
-
 .pd-followup-chip:hover:not(:disabled) {
-  border-color: #1c1917;
-  background: #ffffff;
-  color: #1c1917;
+  border-color: var(--border-str);
+  background: var(--surface);
+  color: var(--text);
 }
 
-/* chip: submitted (confirmed) */
 .pd-followup-chip--done {
-  background: #f0fdf4;
-  border-color: #bbf7d0;
-  color: #15803d;
+  background: var(--green-bg);
+  border-color: var(--green-bd);
+  color: var(--green);
   font-style: normal;
   cursor: default;
 }
 
-/* chip: loading/submitting */
 .pd-followup-chip--loading {
-  background: #f5f4f2;
-  border-color: #e5e4e1;
-  color: #a8a29e;
+  background: var(--surface-sub);
+  border-color: var(--border);
+  color: var(--text-3);
   cursor: wait;
   font-style: normal;
+}
+
+@media (max-width: 640px) {
+  .pd-header { padding: 0 1rem; }
+  .pd-header-code { display: none; }
+  .pd-body { padding: 1.25rem 0.875rem; }
+  .pd-card { padding: 1.125rem 1.25rem; }
+  .pd-cluster { padding: 1rem 1.125rem; }
+}
+
+[data-glass="on"] .pd-header {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom-color: rgba(255, 255, 255, 0.15);
+}
+
+[data-glass="on"] .pd-card,
+[data-glass="on"] .pd-cluster {
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+[data-glass="on"][data-theme="dark"] .pd-header {
+  background: rgba(0, 0, 0, 0.3);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-glass="on"][data-theme="dark"] .pd-card,
+[data-glass="on"][data-theme="dark"] .pd-cluster {
+  background: rgba(0, 0, 0, 0.25);
+  border-color: rgba(255, 255, 255, 0.07);
 }


### PR DESCRIPTION
Dark mode was not applying correctly across the Host dashboard views
despite data-theme="dark" being correctly set on <html>.

Root cause was twofold:
1. CSS variables (:root and [data-theme="dark"]) were defined inside
   Home.css instead of a global file, causing them to conflict or
   not be available on other views.
2. Component CSS files (HostSidebar.css and others) had every color
   hardcoded as hex values instead of using CSS variables, making
   them immune to theme changes entirely.

Changes:
- Created theme.css as the single source of truth for all CSS
  variables (light and dark), imported before index.css in main.jsx

- Removed duplicate :root and [data-theme="dark"] blocks from Home.css

- Rewrote HostSidebar.css to use CSS variables throughout

- Added background: var(--bg) to .hd-main in Host.css

- Added filter: invert(1) to .hd-qr-canvas under [data-theme="dark"]
  so the QR code renders correctly in dark mode

- Moved theme sync to module level in App.jsx to ensure attributes
  are set on <html> before any component renders