### PR TITLE
Adding panel transparency Summary pdf and markdown download options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^5.2.1",
         "express-rate-limit": "^8.4.1",
         "html5-qrcode": "^2.3.8",
+        "jspdf": "^4.2.1",
         "multer": "^2.1.1",
         "pdf-parse": "^1.1.1",
         "qrcode": "^1.5.4",
@@ -229,6 +230,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1168,6 +1178,19 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1193,6 +1216,13 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1344,6 +1374,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1582,6 +1622,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1738,6 +1798,18 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -1797,6 +1869,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -1915,6 +1997,16 @@
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -2446,6 +2538,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2486,6 +2589,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2830,6 +2939,20 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/html5-qrcode": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
@@ -2957,6 +3080,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -3172,6 +3301,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jwa": {
@@ -3911,6 +4057,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3983,6 +4135,13 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4262,6 +4421,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4321,6 +4490,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4353,6 +4529,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rolldown": {
@@ -4770,6 +4956,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -4864,6 +5060,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -4891,6 +5097,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -5089,6 +5305,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "express": "^5.2.1",
     "express-rate-limit": "^8.4.1",
     "html5-qrcode": "^2.3.8",
+    "jspdf": "^4.2.1",
     "multer": "^2.1.1",
     "pdf-parse": "^1.1.1",
     "qrcode": "^1.5.4",

--- a/server/database/SessionStore.js
+++ b/server/database/SessionStore.js
@@ -2,295 +2,313 @@ import supabase from '../database/SupabaseClient.js';
 
 export const SessionStore = {
 
-  async createSession(code, tags = [], title = '', description = '') {
-    // Insert only the base columns that are guaranteed in the schema cache.
-    // title / description / host_notes are updated separately once the cache refreshes.
-    const { error } = await supabase
-      .from('sessions')
-      .insert({ code, phase: 'OPEN', tags, expansion_round: 0, curators: [] });
-    if (error) throw error;
+// Insert only the base columns that are guaranteed in the schema cache.
+// title / description / host_notes are updated separately once the cache refreshes.
+async createSession(code, tags = [], title = '', description = '') {
+const { error } = await supabase
+.from('sessions')
+.insert({ code, phase: 'OPEN', tags, expansion_round: 0, curators: [] });
+if (error) throw error;
 
-    // Best-effort: write the new columns — silently skip if schema cache is stale
-    if (title || description) {
-      supabase.from('sessions')
-        .update({ title, description })
-        .eq('code', code)
-        .then(({ error: e }) => { if (e) console.warn('[createSession] context write skipped:', e.message); });
-    }
-  },
+// Best-effort: write the new columns — silently skip if schema cache is stale
+if (title || description) {
+supabase.from('sessions')
+.update({ title, description })
+.eq('code', code)
+.then(({ error: e }) => { if (e) console.warn('[createSession] context write skipped:', e.message); });
+}
+},
 
-  async getSession(code) {
-    const { data, error } = await supabase
-      .from('sessions')
-      .select('*')
-      .eq('code', code)
-      .single();
-    if (error) throw error;
-    return data;
-  },
+// Retrieve a single session by code
+async getSession(code) {
+const { data, error } = await supabase
+.from('sessions')
+.select('*')
+.eq('code', code)
+.single();
+if (error) throw error;
+return data;
+},
 
-  async updatePhase(code, phase) {
-    const { error } = await supabase
-      .from('sessions')
-      .update({ phase })
-      .eq('code', code);
-    if (error) throw error;
-  },
+// Update the session phase (OPEN, CLOSED, DELETED, etc.)
+async updatePhase(code, phase) {
+const { error } = await supabase
+.from('sessions')
+.update({ phase })
+.eq('code', code);
+if (error) throw error;
+},
 
-  async updateTags(code, tags) {
-    const { error } = await supabase
-      .from('sessions')
-      .update({ tags })
-      .eq('code', code);
-    if (error) throw error;
-  },
+// Replace the tags array for a session
+async updateTags(code, tags) {
+const { error } = await supabase
+.from('sessions')
+.update({ tags })
+.eq('code', code);
+if (error) throw error;
+},
 
-  async updateSessionContext(code, { title, description }) {
-    const { error } = await supabase
-      .from('sessions')
-      .update({ title, description })
-      .eq('code', code);
-    if (error) throw error;
-  },
+// Update title and description together as session context
+async updateSessionContext(code, { title, description }) {
+const { error } = await supabase
+.from('sessions')
+.update({ title, description })
+.eq('code', code);
+if (error) throw error;
+},
 
-  async updateHostNotes(code, hostNotes) {
-    const { error } = await supabase
-      .from('sessions')
-      .update({ host_notes: hostNotes })
-      .eq('code', code);
-    if (error) throw error;
-  },
+// Update host notes field
+async updateHostNotes(code, hostNotes) {
+const { error } = await supabase
+.from('sessions')
+.update({ host_notes: hostNotes })
+.eq('code', code);
+if (error) throw error;
+},
 
-  async deleteSession(code) {
-    const { error } = await supabase
-      .from('sessions')
-      .delete()
-      .eq('code', code);
-    if (error) throw error;
-  },
+// Delete a session and cascade to related rows (DB FK handles cascade)
+async deleteSession(code) {
+const { error } = await supabase
+.from('sessions')
+.delete()
+.eq('code', code);
+if (error) throw error;
+},
 
-  async addSubmission(sessionCode, content) {
-    const { data, error } = await supabase
-      .from('submissions')
-      .insert({ session_code: sessionCode, content, participant_answer: null, is_curator: false })
-      .select()
-      .single();
-    if (error) throw error;
-    return data;
-  },
+// Add a new submission to a session
+async addSubmission(sessionCode, content) {
+const { data, error } = await supabase
+.from('submissions')
+.insert({ session_code: sessionCode, content, participant_answer: null, is_curator: false })
+.select()
+.single();
+if (error) throw error;
+return data;
+},
 
-  async deleteSubmission(id) {
-    const { error } = await supabase
-      .from('submissions')
-      .delete()
-      .eq('id', id);
-    if (error) throw error;
-  },
+// Delete a submission by id
+async deleteSubmission(id) {
+const { error } = await supabase
+.from('submissions')
+.delete()
+.eq('id', id);
+if (error) throw error;
+},
 
-  async getSubmissions(sessionCode) {
-    const { data, error } = await supabase
-      .from('submissions')
-      .select('*')
-      .eq('session_code', sessionCode);
-    if (error) throw error;
-    return data;
-  },
+// Get all submissions for a session
+async getSubmissions(sessionCode) {
+const { data, error } = await supabase
+.from('submissions')
+.select('*')
+.eq('session_code', sessionCode);
+if (error) throw error;
+return data;
+},
 
-  // save participant answer to a specific submission
-  async updateSubmissionAnswer(id, participantAnswer) {
-    const { error } = await supabase
-      .from('submissions')
-      .update({ participant_answer: participantAnswer })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// save participant answer to a specific submission
+async updateSubmissionAnswer(id, participantAnswer) {
+const { error } = await supabase
+.from('submissions')
+.update({ participant_answer: participantAnswer })
+.eq('id', id);
+if (error) throw error;
+},
 
-  async saveClusters(sessionCode, clusters) {
-    // fetch existing clusters so we can preserve their answers
-    const { data: existing } = await supabase
-      .from('clusters')
-      .select('*')
-      .eq('session_code', sessionCode);
+// saveClusters replaces existing clusters for a session while preserving answers when possible
+async saveClusters(sessionCode, clusters) {
+// fetch existing clusters so we can preserve their answers
+const { data: existing } = await supabase
+.from('clusters')
+.select('*')
+.eq('session_code', sessionCode);
 
-    // build a lookup: representative_query -> existing cluster
-    const existingByQuery = {};
-    for (const c of (existing ?? [])) {
-      existingByQuery[c.representative_query] = c;
-    }
+// build a lookup: representative_query -> existing cluster
+const existingByQuery = {};
+for (const c of (existing ?? [])) {
+existingByQuery[c.representative_query] = c;
+}
 
-    const { error: deleteError } = await supabase
-      .from('clusters')
-      .delete()
-      .eq('session_code', sessionCode);
-    if (deleteError) throw deleteError;
+// delete existing clusters for this session (we will re-insert)
+const { error: deleteError } = await supabase
+.from('clusters')
+.delete()
+.eq('session_code', sessionCode);
+if (deleteError) throw deleteError;
 
-    const rows = clusters.map(c => {
-      const prev = existingByQuery[c.representativeQuery];
-      return {
-        session_code: sessionCode,
-        representative_query: c.representativeQuery,
-        submission_count: c.submissionCount,
-        questions: c.questions,
-        // carry over answer, participant_answers, contextual_facts if query matches
-        answer: c.answer ?? prev?.answer ?? null,
-        upvote_count: c.upvoteCount ?? prev?.upvote_count ?? 0,
-        previewed_questions: c.previewedQuestions ?? prev?.previewed_questions ?? [],
-        selected_questions: c.selectedQuestions ?? prev?.selected_questions ?? [],
-        contextual_facts: c.contextualFacts ?? prev?.contextual_facts ?? [],
-        participant_answers: c.participantAnswers ?? prev?.participant_answers ?? [],
-      };
-    });
+// prepare rows, carrying over answers and arrays from previous clusters when queries match
+const rows = clusters.map(c => {
+const prev = existingByQuery[c.representativeQuery];
+return {
+session_code: sessionCode,
+representative_query: c.representativeQuery,
+submission_count: c.submissionCount,
+questions: c.questions,
+// carry over answer, participant_answers, contextual_facts if query matches
+answer: c.answer ?? prev?.answer ?? null,
+upvote_count: c.upvoteCount ?? prev?.upvote_count ?? 0,
+previewed_questions: c.previewedQuestions ?? prev?.previewed_questions ?? [],
+selected_questions: c.selectedQuestions ?? prev?.selected_questions ?? [],
+contextual_facts: c.contextualFacts ?? prev?.contextual_facts ?? [],
+participant_answers: c.participantAnswers ?? prev?.participant_answers ?? [],
+};
+});
 
-    const { data, error } = await supabase
-      .from('clusters')
-      .insert(rows)
-      .select();
-    if (error) throw error;
-    return data;
-  },
+const { data, error } = await supabase
+.from('clusters')
+.insert(rows)
+.select();
+if (error) throw error;
+return data;
+},
 
-  // insert new clusters without deleting existing ones (used for incremental re-clustering)
-  async saveNewClusters(sessionCode, clusters) {
-    if (!clusters.length) return [];
+// insert new clusters without deleting existing ones (used for incremental re-clustering)
+async saveNewClusters(sessionCode, clusters) {
+if (!clusters.length) return [];
 
-    const rows = clusters.map(c => ({
-      session_code: sessionCode,
-      representative_query: c.representativeQuery,
-      submission_count: c.submissionCount,
-      questions: c.questions,
-      answer: null,
-      upvote_count: 0,
-      previewed_questions: [],
-      selected_questions: [],
-      contextual_facts: [],
-      participant_answers: []
-    }));
+const rows = clusters.map(c => ({
+session_code: sessionCode,
+representative_query: c.representativeQuery,
+submission_count: c.submissionCount,
+questions: c.questions,
+answer: null,
+upvote_count: 0,
+previewed_questions: [],
+selected_questions: [],
+contextual_facts: [],
+participant_answers: []
+}));
 
-    const { data, error } = await supabase
-      .from('clusters')
-      .insert(rows)
-      .select();
-    if (error) throw error;
-    return data;
-  },
+const { data, error } = await supabase
+.from('clusters')
+.insert(rows)
+.select();
+if (error) throw error;
+return data;
+},
 
-  async deleteCluster(id) {
-    const { error } = await supabase
-      .from('clusters')
-      .delete()
-      .eq('id', id);
-    if (error) throw error;
-  },
+// Delete a single cluster by id
+async deleteCluster(id) {
+const { error } = await supabase
+.from('clusters')
+.delete()
+.eq('id', id);
+if (error) throw error;
+},
 
-  async updateClusterAnswer(id, answer) {
-    const { error } = await supabase
-      .from('clusters')
-      .update({ answer })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// Update the answer text for a cluster
+async updateClusterAnswer(id, answer) {
+const { error } = await supabase
+.from('clusters')
+.update({ answer })
+.eq('id', id);
+if (error) throw error;
+},
 
-  async updateClusterQuery(id, representativeQuery, submissionCount, questions) {
-    const { error } = await supabase
-      .from('clusters')
-      .update({ representative_query: representativeQuery, submission_count: submissionCount, questions })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// Update only the questions array for a cluster
+async updateClusterQuestions(id, questions) {
+const { error } = await supabase
+.from('clusters')
+.update({ questions })
+.eq('id', id);
+if (error) throw error;
+},
 
-  // save ai-previewed follow-up questions to a cluster
-  async updateClusterPreviewedQuestions(id, previewedQuestions) {
-    const { error } = await supabase
-      .from('clusters')
-      .update({ previewed_questions: previewedQuestions })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// Update representative query, submission count, and questions together
+async updateClusterQuery(id, representativeQuery, submissionCount, questions) {
+const { error } = await supabase
+.from('clusters')
+.update({ representative_query: representativeQuery, submission_count: submissionCount, questions })
+.eq('id', id);
+if (error) throw error;
+},
 
-  // save host/participant selected questions from the previewed list
-  async updateClusterSelectedQuestions(id, selectedQuestions) {
-    const { error } = await supabase
-      .from('clusters')
-      .update({ selected_questions: selectedQuestions })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// save ai-previewed follow-up questions to a cluster
+async updateClusterPreviewedQuestions(id, previewedQuestions) {
+const { error } = await supabase
+.from('clusters')
+.update({ previewed_questions: previewedQuestions })
+.eq('id', id);
+if (error) throw error;
+},
 
-  // save contextual facts extracted by ai during expansion
-  async updateClusterContextualFacts(id, contextualFacts) {
-    const { error } = await supabase
-      .from('clusters')
-      .update({ contextual_facts: contextualFacts })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// save host/participant selected questions from the previewed list
+async updateClusterSelectedQuestions(id, selectedQuestions) {
+const { error } = await supabase
+.from('clusters')
+.update({ selected_questions: selectedQuestions })
+.eq('id', id);
+if (error) throw error;
+},
 
-  // append a participant answer to a cluster's participant_answers array
-  async addParticipantAnswerToCluster(id, answer) {
-    const { data: cluster, error: fetchError } = await supabase
-      .from('clusters')
-      .select('participant_answers')
-      .eq('id', id)
-      .single();
-    if (fetchError) throw fetchError;
+// save contextual facts extracted by ai during expansion
+async updateClusterContextualFacts(id, contextualFacts) {
+const { error } = await supabase
+.from('clusters')
+.update({ contextual_facts: contextualFacts })
+.eq('id', id);
+if (error) throw error;
+},
 
-    const updated = [...(cluster.participant_answers ?? []), answer];
-    const { error } = await supabase
-      .from('clusters')
-      .update({ participant_answers: updated })
-      .eq('id', id);
-    if (error) throw error;
-  },
+// append a participant answer to a cluster's participant_answers array
+async addParticipantAnswerToCluster(id, answer) {
+const { data: cluster, error: fetchError } = await supabase
+.from('clusters')
+.select('participant_answers')
+.eq('id', id)
+.single();
+if (fetchError) throw fetchError;
 
-  async getClusters(sessionCode) {
-    const { data, error } = await supabase
-      .from('clusters')
-      .select('*')
-      .eq('session_code', sessionCode)
-      .order('created_at');
-    if (error) throw error;
-    return data;
-  },
+const updated = [...(cluster.participant_answers ?? []), answer];
+const { error } = await supabase
+.from('clusters')
+.update({ participant_answers: updated })
+.eq('id', id);
+if (error) throw error;
+},
 
-    async getUnclosedSessions() {
-    const { data, error } = await supabase
-      .from('sessions')
-      .select('*')
-      
-      /*
-      Use a new DELETED phase instead of ENDED.
-      I want to keep the session around long enough
-      for it be viewable by people who aren't actively
-      participating in the session.
-      */
+// Get clusters for a session ordered by creation time
+async getClusters(sessionCode) {
+const { data, error } = await supabase
+.from('clusters')
+.select('*')
+.eq('session_code', sessionCode)
+.order('created_at');
+if (error) throw error;
+return data;
+},
 
-      .neq('phase', 'DELETED');
-    if (error) throw error;
-    return data;
-  },
+// Return sessions that are not marked DELETED
+async getUnclosedSessions() {
+const { data, error } = await supabase
+.from('sessions')
+.select('*')
+.neq('phase', 'DELETED');
+if (error) throw error;
+return data;
+},
 
-  // promote a participant to curator by socket id
-  async updateCurators(code, curators) {
-    const { error } = await supabase
-      .from('sessions')
-      .update({ curators })
-      .eq('code', code);
-    if (error) throw error;
-  },
+// promote a participant to curator by socket id (or update curator list)
+async updateCurators(code, curators) {
+const { error } = await supabase
+.from('sessions')
+.update({ curators })
+.eq('code', code);
+if (error) throw error;
+},
 
-  // increment expansion round counter
-  async incrementExpansionRound(code) {
-    const { data, error } = await supabase
-      .from('sessions')
-      .select('expansion_round')
-      .eq('code', code)
-      .single();
-    if (error) throw error;
+// increment expansion round counter
+async incrementExpansionRound(code) {
+const { data, error } = await supabase
+.from('sessions')
+.select('expansion_round')
+.eq('code', code)
+.single();
+if (error) throw error;
 
-    const { error: updateError } = await supabase
-      .from('sessions')
-      .update({ expansion_round: (data.expansion_round ?? 0) + 1 })
-      .eq('code', code);
-    if (updateError) throw updateError;
-  }
+const { error: updateError } = await supabase
+.from('sessions')
+.update({ expansion_round: (data.expansion_round ?? 0) + 1 })
+.eq('code', code);
+if (updateError) throw updateError;
+},
 };

--- a/server/managers/SessionManager.js
+++ b/server/managers/SessionManager.js
@@ -32,7 +32,6 @@ export class SessionManager {
     return code;
   }
 
-  // hydrate all non-ended sessions from supabase on server startup
   async hydrate() {
     try {
       const sessions = await SessionStore.getUnclosedSessions();
@@ -79,19 +78,16 @@ export class SessionManager {
       submissionsAtLastCluster: 0,
     };
     this.sessions.set(code, session);
-    // write to DB in background — don't block the response
     SessionStore.createSession(code, tags, title, description).catch(err =>
       console.error('[SessionManager] failed to persist session:', err)
     );
     return session;
   }
 
-  // sync version:  works after hydrate or during active session
   getSession(code) {
     return this.sessions.get(code) || null;
   }
 
-  // async version:  falls back to Supabase if not in memory after server restart
   async getSessionAsync(code) {
     if (this.sessions.has(code)) return this.sessions.get(code);
 
@@ -162,7 +158,6 @@ export class SessionManager {
     await SessionStore.deleteSubmission(submissionId);
   }
 
-  // Trying to move session from server 's memory
   async deleteSession(code) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
@@ -171,7 +166,6 @@ export class SessionManager {
     this.sessions.delete(code);
   }
 
-  // add a participant answer to a specific submission
   async answerSubmission(code, submissionId, answer) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
@@ -205,7 +199,6 @@ export class SessionManager {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
 
-    // clusterId from URL params is a string; cluster.id from DB may be a number
     const cluster = session.clusters.find(c => String(c.id) === String(clusterId));
     if (!cluster) throw new Error('Cluster not found');
     cluster.answer = answer;
@@ -213,7 +206,6 @@ export class SessionManager {
     return cluster;
   }
 
-  // add a participant answer to a cluster
   async addParticipantAnswerToCluster(code, clusterId, answer) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
@@ -226,16 +218,13 @@ export class SessionManager {
     return cluster;
   }
 
-  // save ai-previewed questions to clusters after expansion preview
   async saveExpansionPreview(code, clusterPreviews, contextualFacts) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
 
-    // attach contextual facts to session
     session.contextualFacts = [...(session.contextualFacts ?? []), ...contextualFacts];
 
     for (const preview of clusterPreviews) {
-      // find by actual cluster UUID — not array index
       const cluster = session.clusters.find(c => c.id === preview.clusterId);
       if (!cluster) {
         console.warn(`[saveExpansionPreview] no cluster found for id: ${preview.clusterId}`);
@@ -250,7 +239,6 @@ export class SessionManager {
     return session;
   }
 
-  // toggle a selected previewed question for a cluster
   async toggleSelectedQuestion(code, clusterId, question) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
@@ -261,7 +249,6 @@ export class SessionManager {
     const current = cluster.selected_questions ?? [];
     const alreadySelected = current.includes(question);
 
-    // toggle on or off
     cluster.selected_questions = alreadySelected
       ? current.filter(q => q !== question)
       : [...current, question];
@@ -270,14 +257,11 @@ export class SessionManager {
     return cluster;
   }
 
-  // promote or demote a participant as curator by socket id
   async promoteCurator(code, socketId) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
 
     const already = session.curators.includes(socketId);
-
-    // toggle curator status
     session.curators = already
       ? session.curators.filter(id => id !== socketId)
       : [...session.curators, socketId];
@@ -286,7 +270,6 @@ export class SessionManager {
     return session.curators;
   }
 
-  // trigger expansion: increments round and transitions to EXPANDING
   async triggerExpansion(code) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
@@ -300,9 +283,31 @@ export class SessionManager {
   async endSession(code) {
     const session = this.getSession(code);
     if (!session) throw new Error('Session not found');
+    await this.transitionPhase(code, PHASES.ENDED);
+  }
 
-    // transition to ENDED instead of deleting so summary is still accessible
-    await this.transitionPhase(code, PHASES.ENDED); 
+  async upvoteQuestion(code, questionText, undo = false) {
+    const session = this.getSession(code);
+    if (!session) throw new Error('Session not found');
+
+    let updatedCluster = null;
+    let newCount = 0;
+
+    for (const cluster of session.clusters) {
+      const question = (cluster.questions ?? []).find(q => q.text === questionText);
+      if (question) {
+        question.upvoteCount = Math.max(0, (question.upvoteCount ?? 0) + (undo ? -1 : 1));
+        newCount = question.upvoteCount;
+        updatedCluster = cluster;
+        break;
+      }
+    }
+
+    if (!updatedCluster) throw new Error('Question not found');
+
+    await SessionStore.updateClusterQuestions(updatedCluster.id, updatedCluster.questions);
+
+    return { questionText, upvoteCount: newCount };
   }
 
   restoreSession(code, phase, tags, submissions, clusters) {

--- a/server/routes/Sessions.js
+++ b/server/routes/Sessions.js
@@ -308,30 +308,24 @@ router.post('/sessions/:code/curators', async (req, res) => {
 });
 
 // participant upvotes or un-upvotes a question within a cluster
+// /upvote route
 router.post('/sessions/:code/upvote', async (req, res) => {
   try {
     const { code } = req.params;
     const { questionText, undo } = req.body;
     const sessionManager = req.app.locals.sessionManager;
     const wsManager = req.app.locals.wsManager;
-    const session = sessionManager.getSession(code);
 
-    if (!session) return res.status(404).json({ error: 'Session not found' });
     if (!questionText) return res.status(400).json({ error: 'questionText is required' });
 
-    let updatedCount = 0;
-    for (const cluster of session.clusters) {
-      const question = (cluster.questions ?? []).find(q => q.text === questionText);
-      if (question) {
-        question.upvoteCount = Math.max(0, (question.upvoteCount ?? 0) + (undo ? -1 : 1));
-        updatedCount = question.upvoteCount;
-        break;
-      }
-    }
+    // delegates to SessionManager which persists to Supabase
+    const { upvoteCount } = await sessionManager.upvoteQuestion(code, questionText, undo ?? false);
 
-    wsManager.toSession(code, 'cluster:upvote', { questionText, upvoteCount: updatedCount });
-    res.json({ questionText, upvoteCount: updatedCount });
+    wsManager.toSession(code, 'cluster:upvote', { questionText, upvoteCount });
+    res.json({ questionText, upvoteCount });
   } catch (err) {
+    if (err.message === 'Session not found') return res.status(404).json({ error: err.message });
+    if (err.message === 'Question not found') return res.status(404).json({ error: err.message });
     console.error(err);
     res.status(500).json({ error: 'Failed to record upvote' });
   }

--- a/src/App.css
+++ b/src/App.css
@@ -50,3 +50,12 @@ body, #root {
   padding: 1rem;
   font-family: monospace;
 }
+
+.app-global-bg {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-size: 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}

--- a/src/components/Host.css
+++ b/src/components/Host.css
@@ -846,3 +846,141 @@
   color: #1c1917;
   opacity: 75%;
 }
+
+.hd-root {
+  background: transparent;
+}
+
+.hd-header {
+  background: var(--surface) !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+[data-theme="dark"] .hd-header {
+  background: rgba(28, 25, 23, 0.75) !important;
+}
+
+[data-theme="light"] .hd-header {
+  background: rgba(255, 255, 255, 0.75) !important;
+}
+
+.hd-sidebar-shell {
+  background: transparent;
+}
+
+[data-theme="dark"] .hd-sidebar-shell {
+  background: rgba(28, 25, 23, 0.55);
+}
+
+[data-theme="light"] .hd-sidebar-shell {
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.hd-session-context {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+[data-theme="dark"] .hd-session-context {
+  background: rgba(28, 25, 23, 0.6);
+}
+
+[data-theme="light"] .hd-session-context {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.hd-cluster {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+[data-theme="dark"] .hd-cluster {
+  background: rgba(28, 25, 23, 0.7);
+}
+
+[data-theme="light"] .hd-cluster {
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.hd-main {
+  background: transparent;
+}
+
+/* ── Glassy overrides ───────────────────────────────────────── */
+
+.hd-sidebar-shell {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-right: 1px solid rgba(255,255,255,0.1);
+}
+
+[data-theme="dark"] .hd-sidebar-shell  { background: rgba(28, 25, 23, 0.5); }
+[data-theme="light"] .hd-sidebar-shell { background: rgba(255, 255, 255, 0.45); }
+
+.hd-session-context {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+
+[data-theme="dark"] .hd-session-context  { background: rgba(28, 25, 23, 0.5); }
+[data-theme="light"] .hd-session-context { background: rgba(255, 255, 255, 0.45); }
+
+.hd-sidebar {
+  background: transparent;
+}
+
+.hd-participants {
+  background: transparent;
+}
+
+.hd-cluster {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255,255,255,0.12);
+}
+
+[data-theme="dark"] .hd-cluster  { background: rgba(28, 25, 23, 0.55); }
+[data-theme="light"] .hd-cluster { background: rgba(255, 255, 255, 0.5); }
+
+.hd-answer-display,
+.hd-answer-textarea,
+.hd-manual-input,
+.hd-copy-btn,
+.hd-tag,
+.hd-share-link,
+.hd-preview-q {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+[data-theme="dark"] .hd-answer-display,
+[data-theme="dark"] .hd-answer-textarea,
+[data-theme="dark"] .hd-manual-input,
+[data-theme="dark"] .hd-copy-btn,
+[data-theme="dark"] .hd-tag,
+[data-theme="dark"] .hd-share-link,
+[data-theme="dark"] .hd-preview-q {
+  background: rgba(28, 25, 23, 0.4);
+  border-color: rgba(255,255,255,0.08);
+}
+
+[data-theme="light"] .hd-answer-display,
+[data-theme="light"] .hd-answer-textarea,
+[data-theme="light"] .hd-manual-input,
+[data-theme="light"] .hd-copy-btn,
+[data-theme="light"] .hd-tag,
+[data-theme="light"] .hd-share-link,
+[data-theme="light"] .hd-preview-q {
+  background: rgba(255, 255, 255, 0.35);
+  border-color: rgba(0,0,0,0.08);
+}
+
+.hd-suggestion {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+[data-theme="dark"] .hd-suggestion  { background: rgba(21, 128, 61, 0.12); }
+[data-theme="light"] .hd-suggestion { background: rgba(21, 128, 61, 0.08); }

--- a/src/components/Host.jsx
+++ b/src/components/Host.jsx
@@ -498,6 +498,18 @@ export default function HostDashboard({ code: initialCode, initialTitle = '', in
             }}
           />
         </main>
+
+        <HostHeader
+          phase={phase}
+          participantCount={participantCount}
+          submissionCount={submissionCount}
+          onBack={onBack}
+          onOpenSidebar={onOpenSidebar}
+          darkMode={darkMode}
+          onToggleDark={onToggleDark}
+          bgKey={bgKey}
+          onSelectBg={onSelectBg}
+        />
       </div>
     </div>
   );

--- a/src/components/HostHeader.jsx
+++ b/src/components/HostHeader.jsx
@@ -1,4 +1,17 @@
+import { useState } from "react";
+import { DefaultBackgrounds } from '../assets/backgrounds/index.js';
 import "./HostHeader.css";
+
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+function SettingsIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
 
 function MoonIcon() {
   return (
@@ -20,32 +33,76 @@ function SunIcon() {
   );
 }
 
-export default function HostHeader({ phase, participantCount, submissionCount, onBack, onOpenSidebar, darkMode, onToggleDark }) {
+// ── Background Picker ────────────────────────────────────────────────────────
+
+function BackgroundPicker({ current, onSelect, onClose, darkMode }) {
+  const filtered = Object.entries(DefaultBackgrounds).filter(([key]) =>
+    darkMode ? key.startsWith("night_") : key.startsWith("day_")
+  );
   return (
-    <header className="hd-header">
-      <div className="hd-header-left">
-        <button className="hd-hamburger" onClick={onOpenSidebar} title="Session history">
-          <span /><span /><span />
-        </button>
-        <button className="hd-back" onClick={onBack}>← back</button>
-        <div className="hd-header-meta">
-          <span className="hd-header-label">Host Dashboard</span>
-          <span className={`hd-phase hd-phase--${phase.toLowerCase()}`}>{phase}</span>
+    <div className="pv-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="pv-modal pv-bg-picker">
+        <button className="pv-modal-close" onClick={onClose}>×</button>
+        <h2>Choose Background</h2>
+        <div className="pv-bg-grid">
+          {filtered.map(([key, src]) => (
+            <button key={key} className={`pv-bg-option ${current === key ? "active" : ""}`}
+              onClick={() => { onSelect(key); onClose(); }}>
+              <img src={src} alt={key} />
+              <span>{key.replace(/^(day_|night_)/, '').replace(/([A-Z])/g, ' $1').trim()}</span>
+            </button>
+          ))}
         </div>
       </div>
-      <div className="hd-header-right">
-        <div className="hd-stat">
-          <span className="hd-stat-num">{participantCount}</span>
-          <span className="hd-stat-label">participants</span>
+    </div>
+  );
+}
+
+// ── HostHeader ───────────────────────────────────────────────────────────────
+
+export default function HostHeader({ phase, participantCount, submissionCount, onBack, onOpenSidebar, darkMode, onToggleDark, bgKey, onSelectBg }) {
+  const [showBgPicker, setShowBgPicker] = useState(false);
+
+  return (
+    <>
+      <header className="hd-header">
+        <div className="hd-header-left">
+          <button className="hd-hamburger" onClick={onOpenSidebar} title="Session history">
+            <span /><span /><span />
+          </button>
+          <button className="hd-back" onClick={onBack}>← back</button>
+          <div className="hd-header-meta">
+            <span className="hd-header-label">Host Dashboard</span>
+            <span className={`hd-phase hd-phase--${phase.toLowerCase()}`}>{phase}</span>
+          </div>
         </div>
-        <div className="hd-stat">
-          <span className="hd-stat-num">{submissionCount}</span>
-          <span className="hd-stat-label">submissions</span>
+
+        <div className="hd-header-right">
+          <div className="hd-stat">
+            <span className="hd-stat-num">{participantCount}</span>
+            <span className="hd-stat-label">participants</span>
+          </div>
+          <div className="hd-stat">
+            <span className="hd-stat-num">{submissionCount}</span>
+            <span className="hd-stat-label">submissions</span>
+          </div>
+          <button className="pv-nav-icon-btn" onClick={onToggleDark} title={darkMode ? "Light mode" : "Dark mode"}>
+            {darkMode ? <SunIcon /> : <MoonIcon />}
+          </button>
+          <button className="pv-nav-icon-btn" onClick={() => setShowBgPicker(true)} title="Background">
+            <SettingsIcon />
+          </button>
         </div>
-        <button className="pv-nav-icon-btn" onClick={onToggleDark} title={darkMode ? "Light mode" : "Dark mode"}>
-          {darkMode ? <SunIcon /> : <MoonIcon />}
-        </button>
-      </div>
-    </header>
+      </header>
+
+      {showBgPicker && (
+        <BackgroundPicker
+          current={bgKey}
+          onSelect={onSelectBg}
+          onClose={() => setShowBgPicker(false)}
+          darkMode={darkMode}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/Participant.jsx
+++ b/src/components/Participant.jsx
@@ -381,6 +381,19 @@ export default function Participant({ code, onBack, user, onOpenSidebar, darkMod
             onSubmit={submitQuestion}
             onDelete={deleteSubmission}
           />
+
+          <ParticipantHeader
+            phase={phase}
+            code={code}
+            onBack={onBack}
+            onOpenSidebar={onOpenSidebar}
+            submittedCount={submittedCount}
+            inClusterCount={inClusterCount}
+            darkMode={darkMode}
+            onToggleDark={onToggleDark}
+            bgKey={bgKey}
+            onSelectBg={onSelectBg}
+          />
         </div>
       </div>
     );

--- a/src/components/ParticipantHeader.jsx
+++ b/src/components/ParticipantHeader.jsx
@@ -1,4 +1,17 @@
+import { useState } from "react";
+import { DefaultBackgrounds } from '../assets/backgrounds/index.js';
 import "./Participant.css";
+
+// ── Icons ────────────────────────────────────────────────────────────────────
+
+function SettingsIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
 
 function MoonIcon() {
   return (
@@ -20,42 +33,84 @@ function SunIcon() {
   );
 }
 
-export default function ParticipantHeader({ phase, code, onBack, onOpenSidebar, submittedCount, inClusterCount, darkMode, onToggleDark }) {
-  const showStats = phase === "RESULTS" || phase === "ENDED";
+// ── Background Picker ────────────────────────────────────────────────────────
 
+function BackgroundPicker({ current, onSelect, onClose, darkMode }) {
+  const filtered = Object.entries(DefaultBackgrounds).filter(([key]) =>
+    darkMode ? key.startsWith("night_") : key.startsWith("day_")
+  );
   return (
-    <header className="pd-header">
-      <div className="pd-header-left">
-        <button className="pd-hamburger" onClick={onOpenSidebar} title="Session history">
-          <span /><span /><span />
-        </button>
-        <button className="pd-back" onClick={onBack}>← back</button>
-        <div className="pd-header-meta">
-          <span className="pd-header-label">Participant</span>
-          <span className={`pd-phase pd-phase--${phase.toLowerCase()}`}>{phase}</span>
+    <div className="pv-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="pv-modal pv-bg-picker">
+        <button className="pv-modal-close" onClick={onClose}>×</button>
+        <h2>Choose Background</h2>
+        <div className="pv-bg-grid">
+          {filtered.map(([key, src]) => (
+            <button key={key} className={`pv-bg-option ${current === key ? "active" : ""}`}
+              onClick={() => { onSelect(key); onClose(); }}>
+              <img src={src} alt={key} />
+              <span>{key.replace(/^(day_|night_)/, '').replace(/([A-Z])/g, ' $1').trim()}</span>
+            </button>
+          ))}
         </div>
       </div>
-
-      <div className="pd-header-right">
-        <span className="pd-header-code">{code}</span>
-
-        {showStats && (
-          <div className="pd-header-stats">
-            <div className="pd-hstat">
-              <span className="pd-hstat-num">{submittedCount ?? 0}</span>
-              <span className="pd-hstat-label">submitted</span>
-            </div>
-            <div className="pd-hstat">
-              <span className="pd-hstat-num">{inClusterCount ?? 0}</span>
-              <span className="pd-hstat-label">in cluster</span>
-            </div>
-          </div>
-        )}
-      </div>
-      <button className="pv-nav-icon-btn" onClick={onToggleDark} title={darkMode ? "Light mode" : "Dark mode"}>
-        {darkMode ? <SunIcon /> : <MoonIcon />}
-      </button>
-    </header>
+    </div>
   );
 }
 
+// ── ParticipantHeader ────────────────────────────────────────────────────────
+
+export default function ParticipantHeader({ phase, code, onBack, onOpenSidebar, submittedCount, inClusterCount, darkMode, onToggleDark, bgKey, onSelectBg }) {
+  const [showBgPicker, setShowBgPicker] = useState(false);
+  const showStats = phase === "RESULTS" || phase === "ENDED";
+
+  return (
+    <>
+      <header className="pd-header">
+        <div className="pd-header-left">
+          <button className="pd-hamburger" onClick={onOpenSidebar} title="Session history">
+            <span /><span /><span />
+          </button>
+          <button className="pd-back" onClick={onBack}>← back</button>
+          <div className="pd-header-meta">
+            <span className="pd-header-label">Participant</span>
+            <span className={`pd-phase pd-phase--${phase.toLowerCase()}`}>{phase}</span>
+          </div>
+        </div>
+
+        <div className="pd-header-right">
+          <span className="pd-header-code">{code}</span>
+
+          {showStats && (
+            <div className="pd-header-stats">
+              <div className="pd-hstat">
+                <span className="pd-hstat-num">{submittedCount ?? 0}</span>
+                <span className="pd-hstat-label">submitted</span>
+              </div>
+              <div className="pd-hstat">
+                <span className="pd-hstat-num">{inClusterCount ?? 0}</span>
+                <span className="pd-hstat-label">in cluster</span>
+              </div>
+            </div>
+          )}
+
+          <button className="pv-nav-icon-btn" onClick={onToggleDark} title={darkMode ? "Light mode" : "Dark mode"}>
+            {darkMode ? <SunIcon /> : <MoonIcon />}
+          </button>
+          <button className="pv-nav-icon-btn" onClick={() => setShowBgPicker(true)} title="Background">
+            <SettingsIcon />
+          </button>
+        </div>
+      </header>
+
+      {showBgPicker && (
+        <BackgroundPicker
+          current={bgKey}
+          onSelect={onSelectBg}
+          onClose={() => setShowBgPicker(false)}
+          darkMode={darkMode}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/Summary.css
+++ b/src/components/Summary.css
@@ -1,7 +1,8 @@
 .sv-root {
   padding: 2rem;
-  max-width: 800px;
+  max-width: 780px;
   margin: 0 auto;
+  font-family: 'Inter', system-ui, sans-serif;
 }
 
 .sv-header {
@@ -10,11 +11,15 @@
 }
 
 .sv-title {
-  font-family: 'EB Garamond', serif;
-  font-size: 2rem;
-  font-weight: 600;
-  color: #1c1917;
-  margin-bottom: 0.5rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #0f0e0d;
+  margin-bottom: 0.6rem;
+}
+
+[data-theme="dark"] .sv-title {
+  color: #f0ede8;
 }
 
 .sv-tags {
@@ -22,100 +27,170 @@
   flex-wrap: wrap;
   gap: 0.4rem;
   justify-content: center;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.6rem;
 }
 
 .sv-tag {
-  background: #f5f0eb;
-  color: #78716c;
-  font-size: 0.75rem;
-  padding: 0.2rem 0.6rem;
+  background: #f0ede8;
+  color: #6b6560;
+  font-size: 0.72rem;
+  font-weight: 500;
+  padding: 0.2rem 0.65rem;
   border-radius: 999px;
+  letter-spacing: 0.01em;
+}
+
+[data-theme="dark"] .sv-tag {
+  background: #2a2825;
+  color: #a09890;
 }
 
 .sv-meta {
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   color: #a8a29e;
+}
+
+.sv-download-row {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.sv-download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #ffffff;
+  border: 1.5px solid #1c1917;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #1c1917;
+  cursor: pointer;
+  padding: 5px 14px;
+  transition: opacity 0.15s;
+}
+
+.sv-download-btn:hover {
+  opacity: 0.7;
+}
+
+[data-theme="dark"] .sv-download-btn {
+  background: #1c1917;
+  color: #ffffff;
+  border-color: #ffffff;
 }
 
 .sv-clusters {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .sv-cluster {
-  background: #fff;
-  border: 1px solid #e7e5e4;
-  border-radius: 12px;
-  padding: 1.5rem;
+  background: #ffffff;
+  border: 1px solid #ebe8e4;
+  border-radius: 16px;
+  padding: 1.4rem 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  transition: box-shadow 0.2s;
+}
+
+.sv-cluster:hover {
+  box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+}
+
+[data-theme="dark"] .sv-cluster {
+  background: #1e1c1a;
+  border-color: #2e2c29;
+  box-shadow: none;
 }
 
 .sv-cluster-header {
   display: flex;
   align-items: flex-start;
-  gap: 1rem;
+  gap: 0.85rem;
 }
 
 .sv-cluster-num {
   background: #1c1917;
   color: #fff;
-  font-size: 0.75rem;
-  font-weight: 600;
-  width: 24px;
-  height: 24px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  margin-top: 2px;
+  margin-top: 3px;
 }
 
-.sv-cluster-query {
-  font-family: 'EB Garamond', serif;
-  font-size: 1.1rem;
-  font-weight: 600;
+[data-theme="dark"] .sv-cluster-num {
+  background: #f0ede8;
   color: #1c1917;
 }
 
+.sv-cluster-query {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1c1917;
+  letter-spacing: -0.01em;
+  line-height: 1.4;
+}
+
+[data-theme="dark"] .sv-cluster-query {
+  color: #f0ede8;
+}
+
 .sv-cluster-meta {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: #a8a29e;
-  margin-top: 0.2rem;
+  margin-top: 0.15rem;
 }
 
 .sv-answer {
   background: #f9f7f5;
   border-left: 3px solid #1c1917;
   padding: 0.75rem 1rem;
-  border-radius: 0 8px 8px 0;
+  border-radius: 0 10px 10px 0;
+}
+
+[data-theme="dark"] .sv-answer {
+  background: #252320;
+  border-left-color: #f0ede8;
 }
 
 .sv-answer-label {
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: 0.67rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #a8a29e;
+  letter-spacing: 0.07em;
+  color: #c0b8b0;
   margin-bottom: 0.3rem;
 }
 
 .sv-answer-text {
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   color: #1c1917;
-  line-height: 1.6;
+  line-height: 1.65;
+}
+
+[data-theme="dark"] .sv-answer-text {
+  color: #e0dbd5;
 }
 
 .sv-questions-label {
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: 0.67rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #a8a29e;
+  letter-spacing: 0.07em;
+  color: #c0b8b0;
   margin-bottom: 0.5rem;
 }
 
@@ -125,26 +200,85 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
 }
 
 .sv-question-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   color: #44403c;
-  padding: 0.4rem 0;
-  border-bottom: 1px solid #f5f0eb;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #f0ede8;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .sv-question-item:last-child {
   border-bottom: none;
 }
 
+[data-theme="dark"] .sv-question-item {
+  color: #c0b8b0;
+  border-bottom-color: #2a2825;
+}
+
 .sv-upvote {
-  font-size: 0.8rem;
-  color: #a8a29e;
+  font-size: 0.78rem;
+  color: #c0b8b0;
   flex-shrink: 0;
   margin-left: 1rem;
 }
+
+.sv-answer-label {
+  font-size: 0.67rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #78716c;
+  background: #f0ede8;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  display: inline-block;
+  margin-bottom: 0.6rem;
+}
+
+.sv-questions-label {
+  font-size: 0.67rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #78716c;
+  background: #f0ede8;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  display: inline-block;
+  margin-bottom: 0.6rem;
+}
+
+[data-theme="dark"] .sv-answer-label,
+[data-theme="dark"] .sv-questions-label {
+  background: #2a2825;
+  color: #a09890;
+}
+
+.sv-cluster {
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255,255,255,0.15);
+}
+
+[data-theme="dark"] .sv-cluster  { background: rgba(28, 25, 23, 0.55); }
+[data-theme="light"] .sv-cluster { background: rgba(255, 255, 255, 0.5); }
+
+.sv-answer {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+[data-theme="dark"] .sv-answer  { background: rgba(28, 25, 23, 0.4); }
+[data-theme="light"] .sv-answer { background: rgba(255, 255, 255, 0.35); }
+
+[data-theme="light"] .sv-root   { background: transparent; }
+[data-theme="dark"] .sv-root    { background: transparent; }

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -1,25 +1,174 @@
+import { jsPDF } from "jspdf";
 import "./Summary.css";
 
 export default function SummaryView({ clusters, answers, tags, submissionCount }) {
+
+  function downloadMarkdown() {
+    const lines = [];
+    lines.push("# Session Summary");
+    if (tags?.length) lines.push(`**Topics:** ${tags.join(", ")}`);
+    lines.push(`${clusters.length} cluster${clusters.length !== 1 ? "s" : ""} · ${submissionCount} total submission${submissionCount !== 1 ? "s" : ""}`);
+    lines.push("");
+
+    clusters.forEach((cluster, i) => {
+      const topQuestions = [...(cluster.questions ?? [])]
+        .sort((a, b) => (b.upvoteCount ?? 0) - (a.upvoteCount ?? 0))
+        .slice(0, 5);
+
+      lines.push(`## ${i + 1}. ${cluster.representative_query}`);
+      lines.push(`*${cluster.submission_count} submission${cluster.submission_count !== 1 ? "s" : ""}*`);
+      lines.push("");
+
+      if (answers[cluster.id]) {
+        lines.push("**Host response**");
+        lines.push(answers[cluster.id]);
+        lines.push("");
+      }
+      if (cluster.selected_questions?.length) {
+        lines.push("**AI recommended questions**");
+        cluster.selected_questions.forEach(q => lines.push(`- ${q}`));
+        lines.push("");
+      }
+      if (topQuestions.length) {
+        lines.push("**Top questions**");
+        topQuestions.forEach(q => {
+          lines.push(`- ${q.text}${q.upvoteCount > 0 ? ` ▲ ${q.upvoteCount}` : ""}`);
+        });
+        lines.push("");
+      }
+      if (cluster.participant_answers?.length) {
+        lines.push("**Participant answers**");
+        cluster.participant_answers.forEach(a => lines.push(`- ${a}`));
+        lines.push("");
+      }
+    });
+
+    const blob = new Blob([lines.join("\n")], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "session-summary.md";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function downloadPdf() {
+    const doc = new jsPDF({ unit: "pt", format: "a4" });
+    const pageW = doc.internal.pageSize.getWidth();
+    const margin = 48;
+    const maxW = pageW - margin * 2;
+    let y = 48;
+
+    function checkPage(needed = 20) {
+      if (y + needed > doc.internal.pageSize.getHeight() - 48) {
+        doc.addPage();
+        y = 48;
+      }
+    }
+
+    function writeText(text, { fontSize = 11, bold = false, color = "#1c1917", indent = 0 } = {}) {
+      doc.setFontSize(fontSize);
+      doc.setFont("helvetica", bold ? "bold" : "normal");
+      doc.setTextColor(color);
+      const lines = doc.splitTextToSize(text, maxW - indent);
+      lines.forEach(line => {
+        checkPage();
+        doc.text(line, margin + indent, y);
+        y += fontSize * 1.45;
+      });
+    }
+
+    // title
+    writeText("Session Summary", { fontSize: 22, bold: true });
+    y += 4;
+    if (tags?.length) writeText(`Topics: ${tags.join(", ")}`, { fontSize: 10, color: "#78716c" });
+    writeText(
+      `${clusters.length} cluster${clusters.length !== 1 ? "s" : ""} · ${submissionCount} total submission${submissionCount !== 1 ? "s" : ""}`,
+      { fontSize: 10, color: "#78716c" }
+    );
+    y += 16;
+
+    clusters.forEach((cluster, i) => {
+      const topQuestions = [...(cluster.questions ?? [])]
+        .sort((a, b) => (b.upvoteCount ?? 0) - (a.upvoteCount ?? 0))
+        .slice(0, 5);
+
+      checkPage(40);
+      // cluster number circle approximation — just bold number + query
+      writeText(`${i + 1}. ${cluster.representative_query}`, { fontSize: 13, bold: true });
+      writeText(`${cluster.submission_count} submission${cluster.submission_count !== 1 ? "s" : ""}`, { fontSize: 9, color: "#a8a29e" });
+      y += 6;
+
+      if (answers[cluster.id]) {
+        writeText("Host response", { fontSize: 10, bold: true, color: "#44403c" });
+        writeText(answers[cluster.id], { fontSize: 10, color: "#57534e", indent: 8 });
+        y += 4;
+      }
+
+      if (cluster.selected_questions?.length) {
+        writeText("AI recommended questions", { fontSize: 10, bold: true, color: "#44403c" });
+        cluster.selected_questions.forEach(q => writeText(`• ${q}`, { fontSize: 10, color: "#57534e", indent: 8 }));
+        y += 4;
+      }
+
+      if (topQuestions.length) {
+        writeText("Top questions", { fontSize: 10, bold: true, color: "#44403c" });
+        topQuestions.forEach(q => {
+          const votes = q.upvoteCount > 0 ? `  ▲ ${q.upvoteCount}` : "";
+          writeText(`• ${q.text}${votes}`, { fontSize: 10, color: "#57534e", indent: 8 });
+        });
+        y += 4;
+      }
+
+      if (cluster.participant_answers?.length) {
+        writeText("Participant answers", { fontSize: 10, bold: true, color: "#44403c" });
+        cluster.participant_answers.forEach(a => writeText(`• ${a}`, { fontSize: 10, color: "#57534e", indent: 8 }));
+        y += 4;
+      }
+
+      y += 16;
+      // divider
+      checkPage();
+      doc.setDrawColor("#e5e4e1");
+      doc.line(margin, y, pageW - margin, y);
+      y += 16;
+    });
+
+    doc.save("session-summary.pdf");
+  }
+
   return (
     <div className="sv-root">
       <div className="sv-header">
         <div className="sv-title">Session Summary</div>
         {tags?.length > 0 && (
           <div className="sv-tags">
-            {tags.map(t => (
-              <span key={t} className="sv-tag">{t}</span>
-            ))}
+            {tags.map(t => <span key={t} className="sv-tag">{t}</span>)}
           </div>
         )}
         <div className="sv-meta">
           {clusters.length} cluster{clusters.length !== 1 ? "s" : ""} · {submissionCount} total submission{submissionCount !== 1 ? "s" : ""}
         </div>
+        <div className="sv-download-row">
+          <button className="sv-download-btn" onClick={downloadMarkdown}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 13v8m0 0l-3-3m3 3l3-3"/>
+              <path d="M6.6 17A5 5 0 0 1 7 7h.1A7 7 0 0 1 19 9.5 4.5 4.5 0 0 1 17.5 18"/>
+            </svg>
+            Markdown
+          </button>
+          <button className="sv-download-btn" onClick={downloadPdf}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 13v8m0 0l-3-3m3 3l3-3"/>
+              <path d="M6.6 17A5 5 0 0 1 7 7h.1A7 7 0 0 1 19 9.5 4.5 4.5 0 0 1 17.5 18"/>
+            </svg>
+            PDF
+          </button>
+        </div>
       </div>
-
+      {/* rest of your clusters JSX unchanged */}
       <div className="sv-clusters">
         {clusters.map((cluster, i) => {
-          // sort participant questions by upvotes, show TOPp 5
           const topQuestions = [...(cluster.questions ?? [])]
             .sort((a, b) => (b.upvoteCount ?? 0) - (a.upvoteCount ?? 0))
             .slice(0, 5);
@@ -35,27 +184,22 @@ export default function SummaryView({ clusters, answers, tags, submissionCount }
                   </div>
                 </div>
               </div>
-
               {answers[cluster.id] && (
                 <div className="sv-answer">
                   <div className="sv-answer-label">Host response</div>
                   <div className="sv-answer-text">{answers[cluster.id]}</div>
                 </div>
               )}
-
               {cluster.selected_questions?.length > 0 && (
                 <div className="sv-expansion-questions">
                   <div className="sv-questions-label">AI recommended questions</div>
                   <ul className="sv-questions-list">
                     {cluster.selected_questions.map((q, qi) => (
-                      <li key={qi} className="sv-question-item">
-                        <span className="sv-question-text">{q}</span>
-                      </li>
+                      <li key={qi} className="sv-question-item"><span className="sv-question-text">{q}</span></li>
                     ))}
                   </ul>
                 </div>
               )}
-
               {topQuestions.length > 0 && (
                 <div className="sv-questions">
                   <div className="sv-questions-label">Top questions</div>
@@ -63,15 +207,12 @@ export default function SummaryView({ clusters, answers, tags, submissionCount }
                     {topQuestions.map((q, qi) => (
                       <li key={qi} className="sv-question-item">
                         <span className="sv-question-text">{q.text}</span>
-                        {q.upvoteCount > 0 && (
-                          <span className="sv-upvote">▲ {q.upvoteCount}</span>
-                        )}
+                        {q.upvoteCount > 0 && <span className="sv-upvote">▲ {q.upvoteCount}</span>}
                       </li>
                     ))}
                   </ul>
                 </div>
               )}
-
               {cluster.participant_answers?.length > 0 && (
                 <div className="sv-participant-answers">
                   <div className="sv-questions-label">Participant answers</div>


### PR DESCRIPTION
Session Summary View Changes Made

Modernized all sv-* styles: switched from serif to clean sans-serif, tightened spacing, added hover lift on cards, unified dark mode throughout
Made sv-cluster cards glassy with backdrop-filter: blur and semi-transparent backgrounds for both light and dark themes
Added [data-theme]-aware download buttons (sv-download-btn) black on white in light mode, white on black in dark mode
Replaced ↓ arrow text in download buttons with an inline cloud-download SVG icon using stroke="currentColor" so it inherits theme colors automatically
Added grey pill badges for section labels (TOP QUESTIONS, ANSWER) inside each cluster card using display: inline-block with rounded backgrounds
Fixed long question overflow with word-break: break-word and overflow-wrap: break-word

Host & Participant Dashboards Changes Made

Applied glassy backdrop-filter: blur(16px) treatment across header, sidebar, session context bar, cluster cards, inputs, tags, answer areas, and suggestion boxes
Set all root/main/body containers to background: transparent so the global background GIF shows through
Scaled background image down with background-size: 100% to capture more detail from high-resolution (2K–4K) images
Added background picker cogwheel button to both HostHeader and ParticipantHeader, matching the existing Home page implementation
bgKey and onSelectBg props wired through to both header components; already available via {themeProps} in App.jsx